### PR TITLE
feat: insert update delete playground

### DIFF
--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -2216,6 +2216,287 @@ const docTemplate = `{
                 }
             }
         },
+        "/playgrounds": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new playground",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/playgrounds/me": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a playground by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a playground by assignment ID and user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Query Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundMeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a playground by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Query Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundMeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/playgrounds/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a playground by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Playground ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/profile": {
             "get": {
                 "security": [
@@ -3470,6 +3751,140 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "value": {
+                    "type": "number"
+                }
+            }
+        },
+        "types.PlaygroundData": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.PlaygroundItem"
+                    }
+                },
+                "meta_data": {
+                    "$ref": "#/definitions/types.PlaygroundMetaData"
+                },
+                "ui": {
+                    "$ref": "#/definitions/types.PlaygroundUI"
+                }
+            }
+        },
+        "types.PlaygroundItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "instruction": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "next": {
+                    "type": "integer"
+                },
+                "next_false": {
+                    "type": "integer"
+                },
+                "next_true": {
+                    "type": "integer"
+                },
+                "operands": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.PlaygroundOperands"
+                    }
+                }
+            }
+        },
+        "types.PlaygroundMeRequest": {
+            "type": "object",
+            "required": [
+                "assignment_id"
+            ],
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PlaygroundMetaData": {
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "integer"
+                },
+                "program_name": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.PlaygroundOperands": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.PlaygroundPosition": {
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "integer"
+                },
+                "y": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PlaygroundRequest": {
+            "type": "object",
+            "required": [
+                "assignment_id",
+                "attempt_no",
+                "item",
+                "status"
+            ],
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "item": {
+                    "$ref": "#/definitions/types.PlaygroundData"
+                },
+                "status": {
+                    "description": "e.g., \"in_progress\", \"completed\", \"failed\"",
+                    "type": "string"
+                }
+            }
+        },
+        "types.PlaygroundUI": {
+            "type": "object",
+            "properties": {
+                "pan": {
+                    "$ref": "#/definitions/types.PlaygroundPosition"
+                },
+                "position": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/types.PlaygroundPosition"
+                    }
+                },
+                "zoom": {
                     "type": "number"
                 }
             }

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -2208,6 +2208,287 @@
                 }
             }
         },
+        "/playgrounds": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new playground",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/playgrounds/me": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update a playground by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a playground by assignment ID and user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Query Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundMeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a playground by user ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "description": "Playground Query Data",
+                        "name": "playground",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.PlaygroundMeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/playgrounds/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a playground by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "playgrounds"
+                ],
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Playground ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/profile": {
             "get": {
                 "security": [
@@ -3462,6 +3743,140 @@
                     "type": "integer"
                 },
                 "value": {
+                    "type": "number"
+                }
+            }
+        },
+        "types.PlaygroundData": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.PlaygroundItem"
+                    }
+                },
+                "meta_data": {
+                    "$ref": "#/definitions/types.PlaygroundMetaData"
+                },
+                "ui": {
+                    "$ref": "#/definitions/types.PlaygroundUI"
+                }
+            }
+        },
+        "types.PlaygroundItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "instruction": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "next": {
+                    "type": "integer"
+                },
+                "next_false": {
+                    "type": "integer"
+                },
+                "next_true": {
+                    "type": "integer"
+                },
+                "operands": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.PlaygroundOperands"
+                    }
+                }
+            }
+        },
+        "types.PlaygroundMeRequest": {
+            "type": "object",
+            "required": [
+                "assignment_id"
+            ],
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PlaygroundMetaData": {
+            "type": "object",
+            "properties": {
+                "author_id": {
+                    "type": "integer"
+                },
+                "program_name": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.PlaygroundOperands": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.PlaygroundPosition": {
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "integer"
+                },
+                "y": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PlaygroundRequest": {
+            "type": "object",
+            "required": [
+                "assignment_id",
+                "attempt_no",
+                "item",
+                "status"
+            ],
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "item": {
+                    "$ref": "#/definitions/types.PlaygroundData"
+                },
+                "status": {
+                    "description": "e.g., \"in_progress\", \"completed\", \"failed\"",
+                    "type": "string"
+                }
+            }
+        },
+        "types.PlaygroundUI": {
+            "type": "object",
+            "properties": {
+                "pan": {
+                    "$ref": "#/definitions/types.PlaygroundPosition"
+                },
+                "position": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/types.PlaygroundPosition"
+                    }
+                },
+                "zoom": {
                     "type": "number"
                 }
             }

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -251,6 +251,94 @@ definitions:
       value:
         type: number
     type: object
+  types.PlaygroundData:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/types.PlaygroundItem'
+        type: array
+      meta_data:
+        $ref: '#/definitions/types.PlaygroundMetaData'
+      ui:
+        $ref: '#/definitions/types.PlaygroundUI'
+    type: object
+  types.PlaygroundItem:
+    properties:
+      id:
+        type: integer
+      instruction:
+        type: string
+      label:
+        type: string
+      next:
+        type: integer
+      next_false:
+        type: integer
+      next_true:
+        type: integer
+      operands:
+        items:
+          $ref: '#/definitions/types.PlaygroundOperands'
+        type: array
+    type: object
+  types.PlaygroundMeRequest:
+    properties:
+      assignment_id:
+        type: integer
+    required:
+    - assignment_id
+    type: object
+  types.PlaygroundMetaData:
+    properties:
+      author_id:
+        type: integer
+      program_name:
+        type: string
+      timestamp:
+        type: string
+    type: object
+  types.PlaygroundOperands:
+    properties:
+      type:
+        type: string
+      value:
+        type: string
+    type: object
+  types.PlaygroundPosition:
+    properties:
+      x:
+        type: integer
+      "y":
+        type: integer
+    type: object
+  types.PlaygroundRequest:
+    properties:
+      assignment_id:
+        type: integer
+      attempt_no:
+        type: integer
+      item:
+        $ref: '#/definitions/types.PlaygroundData'
+      status:
+        description: e.g., "in_progress", "completed", "failed"
+        type: string
+    required:
+    - assignment_id
+    - attempt_no
+    - item
+    - status
+    type: object
+  types.PlaygroundUI:
+    properties:
+      pan:
+        $ref: '#/definitions/types.PlaygroundPosition'
+      position:
+        additionalProperties:
+          $ref: '#/definitions/types.PlaygroundPosition'
+        type: object
+      zoom:
+        type: number
+    type: object
   types.SignInRequest:
     properties:
       email:
@@ -1827,6 +1915,184 @@ paths:
       summary: Subtract numbers
       tags:
       - operations
+  /playgrounds:
+    post:
+      consumes:
+      - application/json
+      description: Create a new playground
+      parameters:
+      - description: Playground Data
+        in: body
+        name: playground
+        required: true
+        schema:
+          $ref: '#/definitions/types.PlaygroundRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      tags:
+      - playgrounds
+  /playgrounds/{id}:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a playground by its ID
+      parameters:
+      - description: Playground ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      tags:
+      - playgrounds
+  /playgrounds/me:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a playground by user ID
+      parameters:
+      - description: Playground Query Data
+        in: body
+        name: playground
+        required: true
+        schema:
+          $ref: '#/definitions/types.PlaygroundMeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      tags:
+      - playgrounds
+    post:
+      consumes:
+      - application/json
+      description: Retrieve a playground by assignment ID and user ID
+      parameters:
+      - description: Playground Query Data
+        in: body
+        name: playground
+        required: true
+        schema:
+          $ref: '#/definitions/types.PlaygroundMeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      tags:
+      - playgrounds
+    put:
+      consumes:
+      - application/json
+      description: Update a playground by user ID
+      parameters:
+      - description: Playground Data
+        in: body
+        name: playground
+        required: true
+        schema:
+          $ref: '#/definitions/types.PlaygroundRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      tags:
+      - playgrounds
   /profile:
     get:
       consumes:

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -99,6 +99,10 @@ func (s *Server) Router() (http.Handler, func()) {
 	systemsUseCase := usecases.NewSystemsUseCase(systemsRepository)
 	systemsController := controller.NewSystemsController(systemsUseCase)
 
+	playgroundRepository := repository.NewPlaygroundRepository(s.db)
+	playgroundUseCase := usecases.NewPlaygroundUseCases(playgroundRepository)
+	playgroundController := controller.NewPlaygroundController(playgroundUseCase)
+
 	api := r.Group("/api/v2")
 	{
 		oauthController.OAuthRegisterRoutes(api)
@@ -160,7 +164,10 @@ func (s *Server) Router() (http.Handler, func()) {
 		{
 			systemsController.SystemsRoutes(systemsGroup)
 		}
-
+		playgroundGroup := api.Group("/playgrounds").Use(security.Middleware()).(*gin.RouterGroup)
+		{
+			playgroundController.PlaygroundRoutes(playgroundGroup)
+		}
 	}
 	if config.ENV == "dev" || config.ENV == "uat" {
 		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))

--- a/internal/services/controller/playground.controller.go
+++ b/internal/services/controller/playground.controller.go
@@ -1,0 +1,213 @@
+package controller
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type PlaygroundController struct {
+	playgroundUsecase usecases.PlaygroundUsecase
+}
+
+func NewPlaygroundController(playgroundUsecase usecases.PlaygroundUsecase) *PlaygroundController {
+	return &PlaygroundController{
+		playgroundUsecase: playgroundUsecase,
+	}
+}
+
+// CreatePlayground handles the request to create a new playground
+// @Description  Create a new playground
+// @Tags         playgrounds
+// @Accept       json
+// @Produce      json
+// @Param        playground body      types.PlaygroundRequest  true  "Playground Data"
+// @Success      201   {object}  map[string]interface{}
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /playgrounds [post]
+func (p *PlaygroundController) CreatePlayground(ctx *gin.Context) {
+	var playgroundRequest types.PlaygroundRequest
+	if err := ctx.ShouldBindJSON(&playgroundRequest); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
+		return
+	}
+
+	userIDInterface, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDInterface.(int)
+
+	playgroundResponse, err := p.playgroundUsecase.CreateUseCases(ctx, userID, &playgroundRequest)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, gin.H{
+		"Message": "Playground created successfully",
+		"Data":    playgroundResponse,
+	})
+}
+
+// GetPlaygroundByID handles the request to get a playground by its ID
+// @Description  Retrieve a playground by its ID
+// @Tags         playgrounds
+// @Accept       json
+// @Produce      json
+// @Param        id   path      int  true  "Playground ID"
+// @Success      200   {object}  map[string]interface{}
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /playgrounds/{id} [get]
+func (p *PlaygroundController) GetPlaygroundByID(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDVal.(int)
+
+	playgroundIDParam := ctx.Param("id")
+	playgroundID, err := strconv.Atoi(playgroundIDParam)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid playground ID"})
+		return
+	}
+
+	playgroundResponse, err := p.playgroundUsecase.GetByPlaygroundIDUseCases(ctx, userID, playgroundID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"Message": "Playground retrieved successfully",
+		"Data":    playgroundResponse,
+	})
+}
+
+// GetPlaygroundByMe handles the request to get a playground by assignment ID and user ID
+// @Description  Retrieve a playground by assignment ID and user ID
+// @Tags         playgrounds
+// @Accept       json
+// @Produce      json
+// @Param        playground body      types.PlaygroundMeRequest  true  "Playground Query Data"
+// @Success      200   {object}  map[string]interface{}
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /playgrounds/me [post]
+func (p *PlaygroundController) GetPlaygroundByMe(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDVal.(int)
+
+	var req types.PlaygroundMeRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
+		return
+	}
+
+	playgroundResponse, err := p.playgroundUsecase.GetPlaygroundByMeUseCases(ctx, userID, &req)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"Message": "Playground retrieved successfully",
+		"Data":    playgroundResponse,
+	})
+}
+
+// UpdatePlaygroundByMe handles the request to update a playground by user ID
+// @Description  Update a playground by user ID
+// @Tags         playgrounds
+// @Accept       json
+// @Produce      json
+// @Param        playground body      types.PlaygroundRequest  true  "Playground Data"
+// @Success      200   {object}  map[string]interface{}
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /playgrounds/me [put]
+func (p *PlaygroundController) UpdatePlaygroundByMe(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDVal.(int)
+
+	var playgroundRequest types.PlaygroundRequest
+	if err := ctx.ShouldBindJSON(&playgroundRequest); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
+		return
+	}
+
+	playgroundResponse, err := p.playgroundUsecase.UpdatePlaygroundByMeUseCases(ctx, userID, &playgroundRequest)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"Message": "Playground updated successfully",
+		"Data":    playgroundResponse,
+	})
+}
+
+// DeletePlaygroundByMe handles the request to delete a playground by user ID
+// @Description  Delete a playground by user ID
+// @Tags         playgrounds
+// @Accept       json
+// @Produce      json
+// @Param        playground body      types.PlaygroundMeRequest  true  "Playground Query Data"
+// @Success      200   {object}  map[string]string
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /playgrounds/me [delete]
+func (p *PlaygroundController) DeletePlaygroundByMe(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDVal.(int)
+
+	var req types.PlaygroundMeRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
+		return
+	}
+
+	err := p.playgroundUsecase.DeletePlaygroundByMeUseCases(ctx, userID, &req)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"Message": "Playground deleted successfully",
+	})
+}
+
+func (p *PlaygroundController) PlaygroundRoutes(r *gin.RouterGroup) {
+	r.POST("/", p.CreatePlayground)
+	r.GET("/:id", p.GetPlaygroundByID)
+	r.POST("/me", p.GetPlaygroundByMe)
+	r.PUT("/me", p.UpdatePlaygroundByMe)
+	r.DELETE("/me", p.DeletePlaygroundByMe)
+}

--- a/internal/services/repository/playground.repository.go
+++ b/internal/services/repository/playground.repository.go
@@ -1,0 +1,214 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/model"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+type PlaygroundRepository interface {
+	Create(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error)
+	GetByPlaygroundID(ctx context.Context, userID int, id int) (*types.PlaygroundResponse, error)
+	GetPlaygroundByMe(ctx context.Context, userID int, req *types.PlaygroundMeRequest) (*types.PlaygroundResponse, error)
+	UpdatePlaygroundByMe(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error)
+	DeletePlaygroundByMe(ctx context.Context, userID int, req *types.PlaygroundMeRequest) error
+}
+
+type playgroundRepository struct {
+	db *gorm.DB
+}
+
+func NewPlaygroundRepository(db *gorm.DB) PlaygroundRepository {
+	return &playgroundRepository{db: db}
+}
+
+func (r *playgroundRepository) Create(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error) {
+	var user model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", userID).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("user not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	var assignment model.Assignment
+	if err := r.db.WithContext(ctx).Where("id = ?", playground.AssignmentID).First(&assignment).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("assignment not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find assignment: %w", err)
+	}
+
+	var existingPlayground model.Playground
+	if err := r.db.WithContext(ctx).Where("assignment_id = ? AND user_id = ?", playground.AssignmentID, userID).First(&existingPlayground).Error; err == nil {
+		return nil, fmt.Errorf("playground for this assignment and user already exists: %w", err)
+	}
+
+	item, _ := json.Marshal(playground.Item)
+
+	newPlayground := model.Playground{
+		AssignmentID: int(playground.AssignmentID),
+		UserID:       int(userID),
+		AttemptNO:    playground.AttemptNO,
+		Item:         datatypes.JSON(item),
+		Status:       playground.Status,
+	}
+
+	if err := r.db.WithContext(ctx).Create(&newPlayground).Error; err != nil {
+		return nil, fmt.Errorf("failed to create playground: %w", err)
+	}
+
+	var parseItems types.PlaygroundData
+	if err := json.Unmarshal(newPlayground.Item, &parseItems); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal playground item: %w", err)
+	}
+
+	playgroundResponse := &types.PlaygroundResponse{
+		ID:           int(newPlayground.ID),
+		AssignmentID: newPlayground.AssignmentID,
+		UserID:       newPlayground.UserID,
+		AttemptNO:    newPlayground.AttemptNO,
+		Item:         parseItems,
+		Status:       playground.Status,
+	}
+
+	return playgroundResponse, nil
+}
+
+func (r *playgroundRepository) GetByPlaygroundID(ctx context.Context, userID int, id int) (*types.PlaygroundResponse, error) {
+	var user model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", userID).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("user not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	var playground model.Playground
+	if err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", id, userID).First(&playground).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("playground not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find playground: %w", err)
+	}
+
+	var parseItems types.PlaygroundData
+	if err := json.Unmarshal(playground.Item, &parseItems); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal playground item: %w", err)
+	}
+
+	playgroundResponse := &types.PlaygroundResponse{
+		ID:           int(playground.ID),
+		AssignmentID: playground.AssignmentID,
+		UserID:       playground.UserID,
+		AttemptNO:    playground.AttemptNO,
+		Item:         parseItems,
+		Status:       playground.Status,
+	}
+
+	return playgroundResponse, nil
+}
+
+func (r *playgroundRepository) GetPlaygroundByMe(ctx context.Context, userID int, req *types.PlaygroundMeRequest) (*types.PlaygroundResponse, error) {
+	var user model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", userID).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("user not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	var playground model.Playground
+	if err := r.db.WithContext(ctx).Where("assignment_id = ? AND user_id = ?", req.AssignmentID, userID).First(&playground).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("playground not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find playground: %w", err)
+	}
+
+	var parseItems types.PlaygroundData
+	if err := json.Unmarshal(playground.Item, &parseItems); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal playground item: %w", err)
+	}
+
+	playgroundResponse := &types.PlaygroundResponse{
+		ID:           int(playground.ID),
+		AssignmentID: playground.AssignmentID,
+		UserID:       playground.UserID,
+		AttemptNO:    playground.AttemptNO,
+		Item:         parseItems,
+		Status:       playground.Status,
+	}
+	return playgroundResponse, nil
+}
+
+func (r *playgroundRepository) UpdatePlaygroundByMe(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error) {
+	var user model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", userID).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("user not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find user: %w", err)
+	}
+
+	var existingPlayground model.Playground
+	if err := r.db.WithContext(ctx).Where("assignment_id = ? AND user_id = ?", playground.AssignmentID, userID).First(&existingPlayground).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("playground not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to find playground: %w", err)
+	}
+
+	item, _ := json.Marshal(playground.Item)
+	existingPlayground.AttemptNO = playground.AttemptNO + 1
+	existingPlayground.Item = datatypes.JSON(item)
+	existingPlayground.Status = playground.Status
+
+	if err := r.db.WithContext(ctx).Save(&existingPlayground).Error; err != nil {
+		return nil, fmt.Errorf("failed to update playground: %w", err)
+	}
+
+	var parseItems types.PlaygroundData
+	if err := json.Unmarshal(existingPlayground.Item, &parseItems); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal playground item: %w", err)
+	}
+
+	playgroundResponse := &types.PlaygroundResponse{
+		ID:           int(existingPlayground.ID),
+		AssignmentID: existingPlayground.AssignmentID,
+		UserID:       existingPlayground.UserID,
+		AttemptNO:    existingPlayground.AttemptNO,
+		Item:         parseItems,
+		Status:       existingPlayground.Status,
+	}
+	return playgroundResponse, nil
+}
+
+func (r *playgroundRepository) DeletePlaygroundByMe(ctx context.Context, userID int, req *types.PlaygroundMeRequest) error {
+	var user model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", userID).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("user not found: %w", err)
+		}
+		return fmt.Errorf("failed to find user: %w", err)
+	}
+
+	var existingPlayground model.Playground
+	if err := r.db.WithContext(ctx).Where("assignment_id = ? AND user_id = ?", req.AssignmentID, userID).First(&existingPlayground).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("playground not found: %w", err)
+		}
+		return fmt.Errorf("failed to find playground: %w", err)
+	}
+
+	if err := r.db.WithContext(ctx).Unscoped().Where("id = ?", existingPlayground.ID).Delete(&existingPlayground).Error; err != nil {
+		return fmt.Errorf("failed to hard delete playground: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -246,3 +246,61 @@ type TestCaseAssert struct {
 	Flags    map[string]int `json:"flags" binding:"required"`
 	Halted   bool           `json:"halted" binding:"required"`
 }
+
+type PlaygroundRequest struct {
+	AssignmentID int            `json:"assignment_id" binding:"required"`
+	AttemptNO    int            `json:"attempt_no" binding:"required"`
+	Item         PlaygroundData `json:"item" binding:"required"`
+	Status       string         `json:"status" binding:"required"` // e.g., "in_progress", "completed", "failed"
+}
+
+type PlaygroundData struct {
+	Items    []PlaygroundItem   `json:"items"`
+	MetaData PlaygroundMetaData `json:"meta_data"`
+	UI       PlaygroundUI       `json:"ui"`
+}
+
+type PlaygroundItem struct {
+	ID          int                  `json:"id"`
+	Instruction string               `json:"instruction"`
+	Label       string               `json:"label"`
+	Operands    []PlaygroundOperands `json:"operands"`
+	Next        int                  `json:"next"`
+	NextTrue    int                  `json:"next_true"`
+	NextFalse   int                  `json:"next_false"`
+}
+
+type PlaygroundOperands struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type PlaygroundMetaData struct {
+	ProgramName string `json:"program_name"`
+	AuthorID    int    `json:"author_id"`
+	Timestamp   string `json:"timestamp"`
+}
+
+type PlaygroundPosition struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+type PlaygroundUI struct {
+	Position map[string]PlaygroundPosition `json:"position"`
+	Zoom     float64                       `json:"zoom"`
+	Pan      PlaygroundPosition            `json:"pan"`
+}
+
+type PlaygroundResponse struct {
+	ID           int            `json:"id"`
+	AssignmentID int            `json:"assignment_id"`
+	UserID       int            `json:"user_id"`
+	AttemptNO    int            `json:"attempt_no"`
+	Item         PlaygroundData `json:"item"`
+	Status       string         `json:"status"` // e.g., "in_progress", "completed", "failed"
+}
+
+type PlaygroundMeRequest struct {
+	AssignmentID int `json:"assignment_id" binding:"required"`
+}

--- a/internal/services/usecases/playground.usecases.go
+++ b/internal/services/usecases/playground.usecases.go
@@ -1,0 +1,64 @@
+package usecases
+
+import (
+	"context"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/repository"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+)
+
+type PlaygroundUsecase interface {
+	CreateUseCases(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error)
+	GetByPlaygroundIDUseCases(ctx context.Context, userID int, id int) (*types.PlaygroundResponse, error)
+	GetPlaygroundByMeUseCases(ctx context.Context, userID int, req *types.PlaygroundMeRequest) (*types.PlaygroundResponse, error)
+	UpdatePlaygroundByMeUseCases(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error)
+	DeletePlaygroundByMeUseCases(ctx context.Context, userID int, req *types.PlaygroundMeRequest) error
+}
+
+type playgroundUsecase struct {
+	playgroundRepo repository.PlaygroundRepository
+}
+
+func NewPlaygroundUseCases(playgroundRepo repository.PlaygroundRepository) PlaygroundUsecase {
+	return &playgroundUsecase{playgroundRepo: playgroundRepo}
+}
+
+func (u *playgroundUsecase) CreateUseCases(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error) {
+	playgroundResponse, err := u.playgroundRepo.Create(ctx, userID, playground)
+	if err != nil {
+		return nil, err
+	}
+	return playgroundResponse, nil
+}
+
+func (u *playgroundUsecase) GetByPlaygroundIDUseCases(ctx context.Context, userID int, id int) (*types.PlaygroundResponse, error) {
+	playgroundResponse, err := u.playgroundRepo.GetByPlaygroundID(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	return playgroundResponse, nil
+}
+
+func (u *playgroundUsecase) GetPlaygroundByMeUseCases(ctx context.Context, userID int, req *types.PlaygroundMeRequest) (*types.PlaygroundResponse, error) {
+	playgroundResponse, err := u.playgroundRepo.GetPlaygroundByMe(ctx, userID, req)
+	if err != nil {
+		return nil, err
+	}
+	return playgroundResponse, nil
+}
+
+func (u *playgroundUsecase) UpdatePlaygroundByMeUseCases(ctx context.Context, userID int, playground *types.PlaygroundRequest) (*types.PlaygroundResponse, error) {
+	playgroundResponse, err := u.playgroundRepo.UpdatePlaygroundByMe(ctx, userID, playground)
+	if err != nil {
+		return nil, err
+	}
+	return playgroundResponse, nil
+}
+
+func (u *playgroundUsecase) DeletePlaygroundByMeUseCases(ctx context.Context, userID int, req *types.PlaygroundMeRequest) error {
+	err := u.playgroundRepo.DeletePlaygroundByMe(ctx, userID, req)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a full backend implementation for managing "playgrounds" in the system. It adds new API endpoints, models, repository, use case, and controller logic for CRUD operations related to playgrounds, including support for user-specific queries and updates. The changes are grouped into API specification updates, backend architecture, and data modeling.

**API Specification and Endpoints:**

* Adds comprehensive Swagger documentation and OpenAPI definitions for playground-related data structures (`PlaygroundRequest`, `PlaygroundData`, `PlaygroundItem`, etc.), enabling clear contract for frontend/backend interaction.
* Introduces new RESTful endpoints under `/playgrounds` and `/playgrounds/me` for creating, retrieving, updating, and deleting playgrounds, including user-specific operations.

**Backend Architecture and Routing:**

* Registers the playground repository, use case, and controller in the server setup, and wires up the playground routes with authentication middleware. [[1]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R102-R105) [[2]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640L163-R170)
* Implements the `PlaygroundController` with handler methods for all playground operations (create, get by ID, get by user/assignment, update, delete), including route registration.

**Repository and Data Access Layer:**

* Implements the `PlaygroundRepository` with methods for all CRUD operations, handling user and assignment validation, JSON serialization/deserialization, and database interaction using GORM.

**Data Modeling:**

* Defines new types in `types.go` to represent playground requests, responses, items, operands, metadata, and UI state, ensuring type safety and clarity throughout the backend.