### PR TITLE
Feat/execution

### DIFF
--- a/internal/services/repository/execution.repository.go
+++ b/internal/services/repository/execution.repository.go
@@ -88,7 +88,7 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 			val, _ := strconv.Atoi(valStr)
 			state.Registers[r] = val
 			step.Registers[r] = val
-			// fmt.Printf("    LOAD %s with %d\n", r, val)
+			fmt.Printf("LOAD %s with %d\n", r, val)
 		case "MOV":
 			dst := node.Operands[0].Value // destination register
 			if strings.HasPrefix(node.Operands[1].Value, "#") {
@@ -96,13 +96,13 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 				val, _ := strconv.Atoi(vStr)
 				state.Registers[dst] = val
 				step.Registers[dst] = val
-				// fmt.Printf("    MOV %s with immediate %d\n", dst, val)
+				fmt.Printf("    MOV %s with immediate %d\n", dst, val)
 			} else {
 				src := node.Operands[1].Value // source register
 				val := state.Registers[src]
 				state.Registers[dst] = val
 				step.Registers[dst] = val
-				// fmt.Printf("    MOV %s with %s (%d)\n", dst, src, val)
+				fmt.Printf("    MOV %s with %s (%d)\n", dst, src, val)
 			}
 		case "LABEL":
 			// Labels are handled in findLabel function
@@ -118,6 +118,7 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 			}
 			state.Registers[dst] += addVal
 			step.Registers[dst] = state.Registers[dst]
+			fmt.Printf("    	ADD %s by %d => %d\n", dst, addVal, state.Registers[dst])
 		case "SUB":
 			dst := node.Operands[0].Value // destination register
 			src := node.Operands[1].Value // source register or immediate value
@@ -130,7 +131,7 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 			}
 			state.Registers[dst] -= subVal
 			step.Registers[dst] = state.Registers[dst]
-			// fmt.Printf("    SUB %s by %d => %d\n", dst, subVal, state.Registers[dst])
+			fmt.Printf("    	SUB %s by %d => %d\n", dst, subVal, state.Registers[dst])
 		case "MUL":
 			dst := node.Operands[0].Value
 			src := node.Operands[1].Value
@@ -143,15 +144,17 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 			}
 			state.Registers[dst] *= mulVal
 			step.Registers[dst] = state.Registers[dst]
-			// fmt.Printf("    MUL %s by %d => %d\n", dst, mulVal, state.Registers[dst])
+			fmt.Printf("    	MUL %s by %d => %d\n", dst, mulVal, state.Registers[dst])
 		case "INC":
 			r := node.Operands[0].Value
 			state.Registers[r]++
 			step.Registers[r] = state.Registers[r]
+			fmt.Printf("    INC %s => %d\n", r, state.Registers[r])
 		case "DEC":
 			r := node.Operands[0].Value
 			state.Registers[r]--
 			step.Registers[r] = state.Registers[r]
+			fmt.Printf("    DEC %s => %d\n", r, state.Registers[r])
 		case "PRINT":
 			r := node.Operands[0].Value
 			output := fmt.Sprintf("Output from %s: %d", r, state.Registers[r])
@@ -171,7 +174,7 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 			} else {
 				state.Flags["Z"] = 0
 			}
-			// fmt.Printf("    CMP %s (%d) vs %s (%d) => Z=%d\n", r1, state.Registers[r1], r2, val2, state.Flags["Z"])
+			fmt.Printf("    CMP %s (%d) vs %s (%d) => Z=%d\n", r1, state.Registers[r1], r2, val2, state.Flags["Z"])
 		case "JMP":
 			label := node.Operands[0].Value
 			target := findLabel(program.Items, label)

--- a/internal/services/repository/execution.repository.go
+++ b/internal/services/repository/execution.repository.go
@@ -144,6 +144,14 @@ func (r *executionRepository) ExecutionPlayground(ctx context.Context, userID in
 			state.Registers[dst] *= mulVal
 			step.Registers[dst] = state.Registers[dst]
 			// fmt.Printf("    MUL %s by %d => %d\n", dst, mulVal, state.Registers[dst])
+		case "INC":
+			r := node.Operands[0].Value
+			state.Registers[r]++
+			step.Registers[r] = state.Registers[r]
+		case "DEC":
+			r := node.Operands[0].Value
+			state.Registers[r]--
+			step.Registers[r] = state.Registers[r]
 		case "PRINT":
 			r := node.Operands[0].Value
 			output := fmt.Sprintf("Output from %s: %d", r, state.Registers[r])


### PR DESCRIPTION
This pull request makes changes to the `ExecutionPlayground` function in `internal/services/repository/execution.repository.go` to improve debug output and add support for new instructions. The most important changes include enabling debug print statements for register operations and introducing support for the `INC` and `DEC` instructions.

Debug output improvements:

* Enabled `fmt.Printf` debug statements for register operations (`LOAD`, `MOV`, `ADD`, `SUB`, `MUL`, `CMP`) to provide detailed execution logs during simulation. [[1]](diffhunk://#diff-b1b8222c350944d21caa55878573e28b49585857f8deaea30b9cae7f3d03922fL91-R105) [[2]](diffhunk://#diff-b1b8222c350944d21caa55878573e28b49585857f8deaea30b9cae7f3d03922fR121) [[3]](diffhunk://#diff-b1b8222c350944d21caa55878573e28b49585857f8deaea30b9cae7f3d03922fL133-R134) [[4]](diffhunk://#diff-b1b8222c350944d21caa55878573e28b49585857f8deaea30b9cae7f3d03922fL146-R157) [[5]](diffhunk://#diff-b1b8222c350944d21caa55878573e28b49585857f8deaea30b9cae7f3d03922fL166-R177)

Instruction set expansion:

* Added support for the `INC` (increment) and `DEC` (decrement) instructions, updating the target register and printing the result.