### PR TITLE
fix classroom api and classroom response

### DIFF
--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -147,6 +147,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get all classrooms",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -184,6 +185,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Create a new class",
                 "parameters": [
                     {
                         "description": "Class info",
@@ -247,6 +249,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get all public classrooms",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -281,6 +284,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get class by ID",
                 "parameters": [
                     {
                         "type": "integer",
@@ -333,6 +337,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Update an existing class",
                 "parameters": [
                     {
                         "type": "integer",
@@ -396,7 +401,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete a classroom",
+                "description": "Delete a class\nDelete a classroom",
                 "consumes": [
                     "application/json"
                 ],
@@ -1636,6 +1641,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Join a classroom",
                 "parameters": [
                     {
                         "type": "integer",
@@ -1643,6 +1649,75 @@ const docTemplate = `{
                         "name": "class_id",
                         "in": "path",
                         "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/classroom/{class_id}/member/permission": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Change permission of a member in a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "classrooms"
+                ],
+                "summary": "Change permission of a member in a class",
+                "parameters": [
+                    {
+                        "description": "New role info",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.NewRoleRequest"
+                        }
                     }
                 ],
                 "responses": {
@@ -1702,6 +1777,7 @@ const docTemplate = `{
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get all members of a class by class ID",
                 "parameters": [
                     {
                         "type": "integer",
@@ -3252,6 +3328,9 @@ const docTemplate = `{
         "types.ClassMeResponse": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -3281,8 +3360,17 @@ const docTemplate = `{
         "types.ClassResponse": {
             "type": "object",
             "properties": {
+                "banner_id": {
+                    "type": "integer"
+                },
+                "code": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
+                },
+                "favorite": {
+                    "type": "integer"
                 },
                 "google_course_id": {
                     "type": "string"
@@ -3296,8 +3384,14 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "member_amount": {
+                    "type": "integer"
+                },
                 "owner_id": {
                     "type": "integer"
+                },
+                "owner_name": {
+                    "type": "string"
                 },
                 "status": {
                     "type": "integer"
@@ -3346,6 +3440,9 @@ const docTemplate = `{
                 "topic"
             ],
             "properties": {
+                "banner_id": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -3451,52 +3548,28 @@ const docTemplate = `{
                 },
                 "picture_path": {
                     "type": "string"
+                },
+                "role": {
+                    "type": "string"
                 }
             }
         },
-        "types.PlaygroundData": {
+        "types.NewRoleRequest": {
             "type": "object",
+            "required": [
+                "class_id",
+                "new_role",
+                "user_id"
+            ],
             "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.PlaygroundItem"
-                    }
-                },
-                "meta_data": {
-                    "$ref": "#/definitions/types.PlaygroundMetaData"
-                },
-                "ui": {
-                    "$ref": "#/definitions/types.PlaygroundUI"
-                }
-            }
-        },
-        "types.PlaygroundItem": {
-            "type": "object",
-            "properties": {
-                "id": {
+                "class_id": {
                     "type": "integer"
                 },
-                "instruction": {
+                "new_role": {
                     "type": "string"
                 },
-                "label": {
-                    "type": "string"
-                },
-                "next": {
+                "user_id": {
                     "type": "integer"
-                },
-                "next_false": {
-                    "type": "integer"
-                },
-                "next_true": {
-                    "type": "integer"
-                },
-                "operands": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.PlaygroundOperands"
-                    }
                 }
             }
         },
@@ -3511,47 +3584,10 @@ const docTemplate = `{
                 }
             }
         },
-        "types.PlaygroundMetaData": {
-            "type": "object",
-            "properties": {
-                "author_id": {
-                    "type": "integer"
-                },
-                "program_name": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.PlaygroundOperands": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.PlaygroundPosition": {
-            "type": "object",
-            "properties": {
-                "x": {
-                    "type": "integer"
-                },
-                "y": {
-                    "type": "integer"
-                }
-            }
-        },
         "types.PlaygroundRequest": {
             "type": "object",
             "required": [
                 "assignment_id",
-                "attempt_no",
                 "item",
                 "status"
             ],
@@ -3559,32 +3595,13 @@ const docTemplate = `{
                 "assignment_id": {
                     "type": "integer"
                 },
-                "attempt_no": {
-                    "type": "integer"
-                },
                 "item": {
-                    "$ref": "#/definitions/types.PlaygroundData"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "status": {
                     "description": "e.g., \"in_progress\", \"completed\", \"failed\"",
                     "type": "string"
-                }
-            }
-        },
-        "types.PlaygroundUI": {
-            "type": "object",
-            "properties": {
-                "pan": {
-                    "$ref": "#/definitions/types.PlaygroundPosition"
-                },
-                "position": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/types.PlaygroundPosition"
-                    }
-                },
-                "zoom": {
-                    "type": "number"
                 }
             }
         },
@@ -3610,7 +3627,6 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "flags",
-                "halted",
                 "memory",
                 "register"
             ],
@@ -3623,6 +3639,12 @@ const docTemplate = `{
                 },
                 "halted": {
                     "type": "boolean"
+                },
+                "io_output": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "memory": {
                     "type": "object",
@@ -3646,10 +3668,20 @@ const docTemplate = `{
                 "register"
             ],
             "properties": {
+                "_meta": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "flags": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "integer"
+                    }
+                },
+                "io_input": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
                     }
                 },
                 "memory": {

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -139,6 +139,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get all classrooms",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -176,6 +177,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Create a new class",
                 "parameters": [
                     {
                         "description": "Class info",
@@ -239,6 +241,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get all public classrooms",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -273,6 +276,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get class by ID",
                 "parameters": [
                     {
                         "type": "integer",
@@ -325,6 +329,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Update an existing class",
                 "parameters": [
                     {
                         "type": "integer",
@@ -388,7 +393,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete a classroom",
+                "description": "Delete a class\nDelete a classroom",
                 "consumes": [
                     "application/json"
                 ],
@@ -1628,6 +1633,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Join a classroom",
                 "parameters": [
                     {
                         "type": "integer",
@@ -1635,6 +1641,75 @@
                         "name": "class_id",
                         "in": "path",
                         "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/classroom/{class_id}/member/permission": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Change permission of a member in a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "classrooms"
+                ],
+                "summary": "Change permission of a member in a class",
+                "parameters": [
+                    {
+                        "description": "New role info",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.NewRoleRequest"
+                        }
                     }
                 ],
                 "responses": {
@@ -1694,6 +1769,7 @@
                 "tags": [
                     "classrooms"
                 ],
+                "summary": "Get all members of a class by class ID",
                 "parameters": [
                     {
                         "type": "integer",
@@ -3244,6 +3320,9 @@
         "types.ClassMeResponse": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -3273,8 +3352,17 @@
         "types.ClassResponse": {
             "type": "object",
             "properties": {
+                "banner_id": {
+                    "type": "integer"
+                },
+                "code": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
+                },
+                "favorite": {
+                    "type": "integer"
                 },
                 "google_course_id": {
                     "type": "string"
@@ -3288,8 +3376,14 @@
                 "id": {
                     "type": "integer"
                 },
+                "member_amount": {
+                    "type": "integer"
+                },
                 "owner_id": {
                     "type": "integer"
+                },
+                "owner_name": {
+                    "type": "string"
                 },
                 "status": {
                     "type": "integer"
@@ -3338,6 +3432,9 @@
                 "topic"
             ],
             "properties": {
+                "banner_id": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -3443,52 +3540,28 @@
                 },
                 "picture_path": {
                     "type": "string"
+                },
+                "role": {
+                    "type": "string"
                 }
             }
         },
-        "types.PlaygroundData": {
+        "types.NewRoleRequest": {
             "type": "object",
+            "required": [
+                "class_id",
+                "new_role",
+                "user_id"
+            ],
             "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.PlaygroundItem"
-                    }
-                },
-                "meta_data": {
-                    "$ref": "#/definitions/types.PlaygroundMetaData"
-                },
-                "ui": {
-                    "$ref": "#/definitions/types.PlaygroundUI"
-                }
-            }
-        },
-        "types.PlaygroundItem": {
-            "type": "object",
-            "properties": {
-                "id": {
+                "class_id": {
                     "type": "integer"
                 },
-                "instruction": {
+                "new_role": {
                     "type": "string"
                 },
-                "label": {
-                    "type": "string"
-                },
-                "next": {
+                "user_id": {
                     "type": "integer"
-                },
-                "next_false": {
-                    "type": "integer"
-                },
-                "next_true": {
-                    "type": "integer"
-                },
-                "operands": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.PlaygroundOperands"
-                    }
                 }
             }
         },
@@ -3503,47 +3576,10 @@
                 }
             }
         },
-        "types.PlaygroundMetaData": {
-            "type": "object",
-            "properties": {
-                "author_id": {
-                    "type": "integer"
-                },
-                "program_name": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.PlaygroundOperands": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.PlaygroundPosition": {
-            "type": "object",
-            "properties": {
-                "x": {
-                    "type": "integer"
-                },
-                "y": {
-                    "type": "integer"
-                }
-            }
-        },
         "types.PlaygroundRequest": {
             "type": "object",
             "required": [
                 "assignment_id",
-                "attempt_no",
                 "item",
                 "status"
             ],
@@ -3551,32 +3587,13 @@
                 "assignment_id": {
                     "type": "integer"
                 },
-                "attempt_no": {
-                    "type": "integer"
-                },
                 "item": {
-                    "$ref": "#/definitions/types.PlaygroundData"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "status": {
                     "description": "e.g., \"in_progress\", \"completed\", \"failed\"",
                     "type": "string"
-                }
-            }
-        },
-        "types.PlaygroundUI": {
-            "type": "object",
-            "properties": {
-                "pan": {
-                    "$ref": "#/definitions/types.PlaygroundPosition"
-                },
-                "position": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/types.PlaygroundPosition"
-                    }
-                },
-                "zoom": {
-                    "type": "number"
                 }
             }
         },
@@ -3602,7 +3619,6 @@
             "type": "object",
             "required": [
                 "flags",
-                "halted",
                 "memory",
                 "register"
             ],
@@ -3615,6 +3631,12 @@
                 },
                 "halted": {
                     "type": "boolean"
+                },
+                "io_output": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "memory": {
                     "type": "object",
@@ -3638,10 +3660,20 @@
                 "register"
             ],
             "properties": {
+                "_meta": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "flags": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "integer"
+                    }
+                },
+                "io_input": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
                     }
                 },
                 "memory": {

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -32,6 +32,8 @@ definitions:
     type: object
   types.ClassMeResponse:
     properties:
+      code:
+        type: string
       description:
         type: string
       google_course_id:
@@ -51,8 +53,14 @@ definitions:
     type: object
   types.ClassResponse:
     properties:
+      banner_id:
+        type: integer
+      code:
+        type: string
       description:
         type: string
+      favorite:
+        type: integer
       google_course_id:
         type: string
       google_course_link:
@@ -61,8 +69,12 @@ definitions:
         type: string
       id:
         type: integer
+      member_amount:
+        type: integer
       owner_id:
         type: integer
+      owner_name:
+        type: string
       status:
         type: integer
       topic:
@@ -92,6 +104,8 @@ definitions:
     type: object
   types.CreateClassRequest:
     properties:
+      banner_id:
+        type: integer
       description:
         type: string
       google_course_id:
@@ -168,36 +182,21 @@ definitions:
         type: string
       picture_path:
         type: string
-    type: object
-  types.PlaygroundData:
-    properties:
-      items:
-        items:
-          $ref: '#/definitions/types.PlaygroundItem'
-        type: array
-      meta_data:
-        $ref: '#/definitions/types.PlaygroundMetaData'
-      ui:
-        $ref: '#/definitions/types.PlaygroundUI'
-    type: object
-  types.PlaygroundItem:
-    properties:
-      id:
-        type: integer
-      instruction:
+      role:
         type: string
-      label:
+    type: object
+  types.NewRoleRequest:
+    properties:
+      class_id:
+        type: integer
+      new_role:
         type: string
-      next:
+      user_id:
         type: integer
-      next_false:
-        type: integer
-      next_true:
-        type: integer
-      operands:
-        items:
-          $ref: '#/definitions/types.PlaygroundOperands'
-        type: array
+    required:
+    - class_id
+    - new_role
+    - user_id
     type: object
   types.PlaygroundMeRequest:
     properties:
@@ -206,56 +205,20 @@ definitions:
     required:
     - assignment_id
     type: object
-  types.PlaygroundMetaData:
-    properties:
-      author_id:
-        type: integer
-      program_name:
-        type: string
-      timestamp:
-        type: string
-    type: object
-  types.PlaygroundOperands:
-    properties:
-      type:
-        type: string
-      value:
-        type: string
-    type: object
-  types.PlaygroundPosition:
-    properties:
-      x:
-        type: integer
-      "y":
-        type: integer
-    type: object
   types.PlaygroundRequest:
     properties:
       assignment_id:
         type: integer
-      attempt_no:
-        type: integer
       item:
-        $ref: '#/definitions/types.PlaygroundData'
+        additionalProperties: true
+        type: object
       status:
         description: e.g., "in_progress", "completed", "failed"
         type: string
     required:
     - assignment_id
-    - attempt_no
     - item
     - status
-    type: object
-  types.PlaygroundUI:
-    properties:
-      pan:
-        $ref: '#/definitions/types.PlaygroundPosition'
-      position:
-        additionalProperties:
-          $ref: '#/definitions/types.PlaygroundPosition'
-        type: object
-      zoom:
-        type: number
     type: object
   types.SignUpRequest:
     properties:
@@ -277,6 +240,10 @@ definitions:
         type: object
       halted:
         type: boolean
+      io_output:
+        additionalProperties:
+          type: string
+        type: object
       memory:
         additionalProperties:
           type: integer
@@ -287,15 +254,21 @@ definitions:
         type: object
     required:
     - flags
-    - halted
     - memory
     - register
     type: object
   types.TestCaseInit:
     properties:
+      _meta:
+        additionalProperties: true
+        type: object
       flags:
         additionalProperties:
           type: integer
+        type: object
+      io_input:
+        additionalProperties:
+          type: string
         type: object
       memory:
         additionalProperties:
@@ -493,6 +466,7 @@ paths:
             additionalProperties:
               type: string
             type: object
+      summary: Get all classrooms
       tags:
       - classrooms
     post:
@@ -535,13 +509,16 @@ paths:
             type: object
       security:
       - BearerAuth: []
+      summary: Create a new class
       tags:
       - classrooms
   /classroom/{class_id}:
     delete:
       consumes:
       - application/json
-      description: Delete a classroom
+      description: |-
+        Delete a class
+        Delete a classroom
       parameters:
       - description: Class ID
         in: path
@@ -608,6 +585,7 @@ paths:
             additionalProperties:
               type: string
             type: object
+      summary: Get class by ID
       tags:
       - classrooms
     put:
@@ -655,6 +633,7 @@ paths:
             type: object
       security:
       - BearerAuth: []
+      summary: Update an existing class
       tags:
       - classrooms
   /classroom/{class_id}/assignment:
@@ -1454,6 +1433,51 @@ paths:
             type: object
       security:
       - BearerAuth: []
+      summary: Join a classroom
+      tags:
+      - classrooms
+  /classroom/{class_id}/member/permission:
+    put:
+      consumes:
+      - application/json
+      description: Change permission of a member in a class
+      parameters:
+      - description: New role info
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/types.NewRoleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Change permission of a member in a class
       tags:
       - classrooms
   /classroom/{class_id}/members:
@@ -1490,6 +1514,7 @@ paths:
             type: object
       security:
       - BearerAuth: []
+      summary: Get all members of a class by class ID
       tags:
       - classrooms
   /classroom/public:
@@ -1512,6 +1537,7 @@ paths:
             additionalProperties:
               type: string
             type: object
+      summary: Get all public classrooms
       tags:
       - classrooms
   /google/classroom/courses:

--- a/internal/model/member.go
+++ b/internal/model/member.go
@@ -1,8 +1,12 @@
 package model
 
+import "time"
+
 type Member struct {
 	UserID    int       `gorm:"primaryKey; not null"`
 	ClassID   int       `gorm:"primaryKey; not null"`
+	Role      string    `gorm:"not null; default:'member'"` // roles: member, teacher, ta
+	JoinAt    time.Time `gorm:"not null; default:current_timestamp"`
 	User      User      `gorm:"foreignKey:UserID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Classroom Classroom `gorm:"foreignKey:ClassID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }

--- a/internal/services/controller/class.controller.go
+++ b/internal/services/controller/class.controller.go
@@ -19,6 +19,7 @@ func NewClassController(classUseCase usecases.ClassUseCase) *ClassController {
 	}
 }
 
+// @Summary      Get all classrooms
 // @Description  Retrieve all classrooms
 // @Tags         classrooms
 // @Accept       json
@@ -35,6 +36,7 @@ func (c *ClassController) ClassGetAllClasses(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, classes)
 }
 
+// @Summary      Get class by ID
 // @Description  Retrieve a class by ID
 // @Tags         classrooms
 // @Accept       json
@@ -58,6 +60,7 @@ func (c *ClassController) ClassGetClassByID(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, class)
 }
 
+// @Summary      Create a new class
 // @Description  Create a new class
 // @Tags         classrooms
 // @Accept       json
@@ -95,6 +98,7 @@ func (c *ClassController) ClassCreateClass(ctx *gin.Context) {
 	ctx.JSON(http.StatusCreated, gin.H{"message": "Class created successfully"})
 }
 
+// @Summary      Update an existing class
 // @Description  Update an existing class
 // @Tags         classrooms
 // @Accept       json
@@ -139,6 +143,7 @@ func (c *ClassController) ClassUpdateClass(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"message": "Class updated successfully"})
 }
 
+// @Description  Delete a class
 // @Description  Delete a classroom
 // @Tags         classrooms
 // @Accept       json
@@ -176,6 +181,7 @@ func (c *ClassController) ClassDeleteClass(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"message": "Class deleted successfully"})
 }
 
+// @Summary      Join a classroom
 // @Description  Join a classroom
 // @Tags         classrooms
 // @Accept       json
@@ -214,6 +220,7 @@ func (c *ClassController) JoinClass(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"message": "Joined class successfully"})
 }
 
+// @Summary      Get all members of a class by class ID
 // @Description  Get all members of a class by class ID
 // @Tags         classrooms
 // @Accept       json
@@ -240,6 +247,7 @@ func (c *ClassController) GetAllMembersByClassID(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, members)
 }
 
+// @Summary      Get all public classrooms
 // @Description  Retrieve all public classrooms
 // @Tags         classrooms
 // @Accept       json
@@ -256,12 +264,40 @@ func (c *ClassController) GetAllClassPublic(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, classes)
 }
 
+// @Summary      Change permission of a member in a class
+// @Description  Change permission of a member in a class
+// @Tags         classrooms
+// @Accept       json
+// @Produce      json
+// @Param        body body types.NewRoleRequest true "New role info"
+// @Success      200   {object}  map[string]string
+// @Failure      400   {object}  map[string]string
+// @Failure      401   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /classroom/{class_id}/member/permission [put]
+func (c *ClassController) ChangePermissionMember(ctx *gin.Context) {
+	var newRoleReq types.NewRoleRequest
+	if err := ctx.ShouldBindJSON(&newRoleReq); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	err := c.classUseCase.ChangePermissionMemberUseCases(ctx, newRoleReq.UserID, newRoleReq.ClassID, newRoleReq.NewRole)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"message": "Member role updated successfully"})
+}
+
 func (c *ClassController) ClassRoutes(r gin.IRoutes) {
 	r.POST("/", c.ClassCreateClass)
 	r.PUT("/:class_id", c.ClassUpdateClass)
 	r.DELETE("/:class_id", c.ClassDeleteClass)
 	r.POST("/:class_id/join", c.JoinClass)
 	r.GET("/:class_id/members", c.GetAllMembersByClassID)
+	r.PUT("/:class_id/member/permission", c.ChangePermissionMember)
 }
 
 func (c *ClassController) ClassNotLoginRoutes(rg *gin.RouterGroup) {

--- a/internal/services/repository/class.repository.go
+++ b/internal/services/repository/class.repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/TroJanBoi/assembly-visual-backend/internal/model"
 	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
@@ -18,6 +19,7 @@ type ClassRepository interface {
 	JoinClass(ctx context.Context, userID, classID int) error
 	GetAllMembersByClassID(ctx context.Context, classID int) (*[]types.MemberResponse, error)
 	GetAllClassPublic(ctx context.Context) (*[]types.ClassResponse, error)
+	ChangePermissionMember(ctx context.Context, userID, classID int, newRole string) error
 }
 
 type classRepository struct {
@@ -34,17 +36,32 @@ func (r *classRepository) GetAllClasses(ctx context.Context) (*[]types.ClassResp
 		return nil, err
 	}
 
-	var classResponses []types.ClassResponse
+	classResponses := make([]types.ClassResponse, 0, len(classes))
+
 	for _, class := range classes {
+		var owner model.User
+		if err := r.db.WithContext(ctx).Where("id = ?", class.OwnerId).First(&owner).Error; err != nil {
+			return nil, err
+		}
+
+		var memberCount int64
+		if err := r.db.WithContext(ctx).Model(&model.Member{}).Where("class_id = ?", class.ID).Count(&memberCount).Error; err != nil {
+			return nil, err
+		}
 		classResponses = append(classResponses, types.ClassResponse{
 			ID:               int(class.ID),
 			Topic:            class.Topic,
 			Description:      class.Description,
+			Code:             class.Code,
 			GoogleCourseID:   class.GoogleCourseID,
 			GoogleCourseLink: class.GoogleCourseLink,
 			GoogleSyncedAt:   class.GoogleSyncedAt,
 			OwnerID:          int(class.OwnerId),
+			OwnerName:        owner.Name,
 			Status:           class.Status,
+			MemberAmount:     memberCount,
+			Favorite:         class.Favorite,
+			BannerID:         class.BannerID,
 		})
 	}
 
@@ -66,6 +83,7 @@ func (r *classRepository) CreateClass(ctx context.Context, owner int, class *typ
 		GoogleCourseID:   class.GoogleCourseID,
 		GoogleCourseLink: class.GoogleCourseLink,
 		OwnerId:          owner,
+		BannerID:         class.BannerID,
 		Status:           class.Status,
 	}
 
@@ -101,7 +119,6 @@ func (r *classRepository) UpdateClass(ctx context.Context, owner int, classID in
 	if class.Status != 0 {
 		existingClass.Status = class.Status
 	}
-
 	if err := r.db.WithContext(ctx).Save(&existingClass).Error; err != nil {
 		return err
 	}
@@ -135,15 +152,30 @@ func (r *classRepository) GetClassByID(ctx context.Context, classID int) (*types
 		return nil, err
 	}
 
+	var owner model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", class.OwnerId).First(&owner).Error; err != nil {
+		return nil, err
+	}
+
+	var memberCount int64
+	if err := r.db.WithContext(ctx).Model(&model.Member{}).Where("class_id = ?", class.ID).Count(&memberCount).Error; err != nil {
+		return nil, err
+	}
+
 	classResponse := types.ClassResponse{
 		ID:               int(class.ID),
 		Topic:            class.Topic,
 		Description:      class.Description,
+		Code:             class.Code,
 		GoogleCourseID:   class.GoogleCourseID,
 		GoogleCourseLink: class.GoogleCourseLink,
 		GoogleSyncedAt:   class.GoogleSyncedAt,
 		OwnerID:          int(class.OwnerId),
+		OwnerName:        owner.Name,
+		MemberAmount:     memberCount,
 		Status:           class.Status,
+		Favorite:         class.Favorite,
+		BannerID:         class.BannerID,
 	}
 
 	return &classResponse, nil
@@ -182,6 +214,8 @@ func (r *classRepository) JoinClass(ctx context.Context, userID, classID int) er
 	newMember := model.Member{
 		UserID:  userID,
 		ClassID: classID,
+		JoinAt:  time.Now(),
+		Role:    "member",
 	}
 
 	if err := r.db.WithContext(ctx).Create(&newMember).Error; err != nil {
@@ -209,6 +243,8 @@ func (r *classRepository) GetAllMembersByClassID(ctx context.Context, classID in
 			Name:         user.Name,
 			Email:        user.Email,
 			Picture_path: user.PicturePath,
+			Role:         member.Role,
+			JoinAt:       member.JoinAt,
 		})
 	}
 
@@ -221,19 +257,53 @@ func (r *classRepository) GetAllClassPublic(ctx context.Context) (*[]types.Class
 		return nil, err
 	}
 
-	var classResponses []types.ClassResponse
+	classResponses := make([]types.ClassResponse, 0, len(classes))
+
 	for _, class := range classes {
+		var owner model.User
+		if err := r.db.WithContext(ctx).Where("id = ?", class.OwnerId).First(&owner).Error; err != nil {
+			return nil, err
+		}
+
+		var memberCount int64
+		if err := r.db.WithContext(ctx).Model(&model.Member{}).Where("class_id = ?", class.ID).Count(&memberCount).Error; err != nil {
+			return nil, err
+		}
 		classResponses = append(classResponses, types.ClassResponse{
 			ID:               int(class.ID),
 			Topic:            class.Topic,
 			Description:      class.Description,
+			Code:             class.Code,
 			GoogleCourseID:   class.GoogleCourseID,
 			GoogleCourseLink: class.GoogleCourseLink,
 			GoogleSyncedAt:   class.GoogleSyncedAt,
 			OwnerID:          int(class.OwnerId),
+			OwnerName:        owner.Name,
+			MemberAmount:     memberCount,
 			Status:           class.Status,
+			Favorite:         class.Favorite,
+			BannerID:         class.BannerID,
 		})
 	}
 
 	return &classResponses, nil
+}
+
+func (r *classRepository) ChangePermissionMember(ctx context.Context, userID, classID int, newRole string) error {
+	var member model.Member
+	err := r.db.WithContext(ctx).Where("user_id = ? AND class_id = ?", userID, classID).First(&member).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return gorm.ErrRecordNotFound
+		}
+		return err
+	}
+
+	member.Role = newRole
+
+	if err := r.db.WithContext(ctx).Save(&member).Error; err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/services/repository/user.repository.go
+++ b/internal/services/repository/user.repository.go
@@ -143,6 +143,7 @@ func (r *userRepository) GetMeClass(ctx context.Context, userID int) (*[]types.C
 	for _, class := range classes {
 		classResp = append(classResp, types.ClassMeResponse{
 			ID:          int(class.ID),
+			Code:        class.Code,
 			Topic:       class.Topic,
 			Description: class.Description,
 			OwnerID:     int(class.OwnerId),
@@ -164,6 +165,7 @@ func (r *userRepository) GetOwnerClass(ctx context.Context, userID int) (*[]type
 			Topic:            class.Topic,
 			Description:      class.Description,
 			OwnerID:          int(class.OwnerId),
+			Code:             class.Code,
 			Status:           int(class.Status),
 			GoogleCourseID:   class.GoogleCourseID,
 			GoogleCourseLink: class.GoogleCourseLink,

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -73,9 +73,14 @@ type ChangePasswordRequest struct {
 type ClassResponse struct {
 	ID               int    `json:"id"`
 	OwnerID          int    `json:"owner_id"`
+	OwnerName        string `json:"owner_name"`
+	MemberAmount     int64  `json:"member_amount"`
+	Code             string `json:"code"`
 	Topic            string `json:"topic"`
 	Description      string `json:"description"`
 	Status           int    `json:"status"`
+	Favorite         int    `json:"favorite"`
+	BannerID         int    `json:"banner_id"`
 	GoogleCourseID   string `json:"google_course_id"`
 	GoogleCourseLink string `json:"google_course_link"`
 	GoogleSyncedAt   string `json:"google_synced_at"`
@@ -86,6 +91,7 @@ type CreateClassRequest struct {
 	Description      string `json:"description" binding:"required"`
 	GoogleCourseID   string `json:"google_course_id"`
 	GoogleCourseLink string `json:"google_course_link"`
+	BannerID         int    `json:"banner_id"`
 	Status           int    `json:"status"` // public or private
 }
 
@@ -183,16 +189,19 @@ type EditAssignmentRequest struct {
 }
 
 type MemberResponse struct {
-	ID           int    `json:"id"`
-	Name         string `json:"name"`
-	Email        string `json:"email"`
-	Picture_path string `json:"picture_path"`
+	ID           int       `json:"id"`
+	Name         string    `json:"name"`
+	Email        string    `json:"email"`
+	Picture_path string    `json:"picture_path"`
+	Role         string    `json:"role"`
+	JoinAt       time.Time `json:"join_at"`
 }
 
 type ClassMeResponse struct {
 	ID               int    `json:"id"`
 	Topic            string `json:"topic"`
 	Description      string `json:"description"`
+	Code             string `json:"code"`
 	OwnerID          int    `json:"owner_id"`
 	Status           int    `json:"status"`
 	GoogleCourseID   string `json:"google_course_id"`
@@ -355,4 +364,10 @@ type CreateSubmissionRequest struct {
 	UserID       int `json:"user_id" binding:"required"`
 	PlaygroundID int `json:"playground_id" binding:"required"`
 	AttemptNO    int
+}
+
+type NewRoleRequest struct {
+	ClassID int    `json:"class_id" binding:"required"`
+	UserID  int    `json:"user_id" binding:"required"`
+	NewRole string `json:"new_role" binding:"required"`
 }

--- a/internal/services/usecases/class.usecases.go
+++ b/internal/services/usecases/class.usecases.go
@@ -17,6 +17,7 @@ type ClassUseCase interface {
 	JoinClassUseCases(ctx context.Context, userID, classID int) error
 	GetAllMembersByClassID(ctx context.Context, classID int) (*[]types.MemberResponse, error)
 	GetAllClassPublicUseCases(ctx context.Context) (*[]types.ClassResponse, error)
+	ChangePermissionMemberUseCases(ctx context.Context, userID, classID int, newRole string) error
 }
 
 type classUseCase struct {
@@ -89,4 +90,12 @@ func (uc *classUseCase) GetAllClassPublicUseCases(ctx context.Context) (*[]types
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (uc *classUseCase) ChangePermissionMemberUseCases(ctx context.Context, userID, classID int, newRole string) error {
+	err := uc.classRepo.ChangePermissionMember(ctx, userID, classID, newRole)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This pull request updates the API documentation for classroom-related endpoints, adding more detailed summaries and improving schema definitions. It also introduces a new endpoint for changing a member's permission in a class and updates several data models to include additional fields. Some obsolete or unused playground-related definitions have been removed for clarity.

**API Documentation Improvements:**

* Added `summary` fields to classroom endpoints (e.g., get all classrooms, create class, get class by ID, update class, join classroom, get all members) to make the documentation clearer and easier to navigate. [[1]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R150) [[2]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R188) [[3]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R252) [[4]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R287) [[5]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R340) [[6]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R1644) [[7]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R1780) [[8]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR142) [[9]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR180) [[10]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR244) [[11]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR279) [[12]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR332) [[13]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR1636)
* Clarified the description for the delete classroom endpoint. [[1]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147L399-R404) [[2]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecL391-R396)

**New Endpoint:**

* Added a new endpoint `PUT /classroom/{class_id}/member/permission` to allow changing a member's role within a class, including request/response schema and security requirements. [[1]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R1694-R1762) [[2]](diffhunk://#diff-01e7fb8f517532b2f7ac5502e146dc8f0612a363e8fff5f3f4f1a85ed3acb8ecR1686-R1754)

**Schema and Model Enhancements:**

* Updated `types.ClassMeResponse` and `types.ClassResponse` to include new fields such as `code`, `banner_id`, `favorite`, `member_amount`, and `owner_name`. [[1]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R3331-R3333) [[2]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R3363-R3374) [[3]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R3387-R3395) [[4]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R3443-R3445)
* Added the `role` field to the class member response schema.

**Playground Model Cleanup:**

* Removed several unused or obsolete playground-related schema definitions (e.g., `types.PlaygroundData`, `types.PlaygroundItem`, `types.PlaygroundMetaData`, `types.PlaygroundOperands`, `types.PlaygroundPosition`, `types.PlaygroundUI`) and simplified the `types.PlaygroundRequest` model. [[1]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147L3454-L3499) [[2]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147L3514-L3590)

**Miscellaneous Model Updates:**

* Updated VM state-related models to add new fields like `io_input`, `io_output`, and `_meta`, and removed the `halted` field from required properties. [[1]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147L3613) [[2]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R3643-R3648) [[3]](diffhunk://#diff-0abef5adb549debe09d6c01a4198a4f4d1b5d76f83bbafa24d6d6199c482b147R3671-R3686)