### PR TITLE
api submission

### DIFF
--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -237,6 +237,75 @@ const docTemplate = `{
                 }
             }
         },
+        "/classroom/member": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a member from a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "classrooms"
+                ],
+                "summary": "Remove a member from a class",
+                "parameters": [
+                    {
+                        "description": "Remove member info",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.RemoveMemberRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/classroom/public": {
             "get": {
                 "description": "Retrieve all public classrooms",
@@ -2976,6 +3045,235 @@ const docTemplate = `{
                 }
             }
         },
+        "/submission": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new submission for an assignment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Create a new submission",
+                "parameters": [
+                    {
+                        "description": "Submission Data",
+                        "name": "submission",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateSubmissionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/submission/assignment/{assignment_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a submission for a specific assignment by assignment ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Get submission by assignment ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Assignment ID",
+                        "name": "assignment_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SubmissionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/submission/{submission_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a submission by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Get submission by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Submission ID",
+                        "name": "submission_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SubmissionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update an existing submission by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Update an existing submission",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Submission ID",
+                        "name": "submission_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated Submission Data",
+                        "name": "submission",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateSubmissionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "get": {
                 "security": [
@@ -3461,6 +3759,44 @@ const docTemplate = `{
                 }
             }
         },
+        "types.CreateSubmissionRequest": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "client_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "item_snapshot": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "playground_id": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "server_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "types.CreateUserRequest": {
             "type": "object",
             "required": [
@@ -3543,6 +3879,9 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "join_at": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3605,6 +3944,21 @@ const docTemplate = `{
                 }
             }
         },
+        "types.RemoveMemberRequest": {
+            "type": "object",
+            "required": [
+                "class_id",
+                "user_id"
+            ],
+            "properties": {
+                "class_id": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.SignUpRequest": {
             "type": "object",
             "required": [
@@ -3620,6 +3974,56 @@ const docTemplate = `{
                 },
                 "password": {
                     "type": "string"
+                }
+            }
+        },
+        "types.SubmissionResponse": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "client_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "item_snapshot": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "playground_id": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "server_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -3782,6 +4186,44 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "topic": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UpdateSubmissionRequest": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "client_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "item_snapshot": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "playground_id": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "server_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
                     "type": "string"
                 }
             }

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -229,6 +229,75 @@
                 }
             }
         },
+        "/classroom/member": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a member from a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "classrooms"
+                ],
+                "summary": "Remove a member from a class",
+                "parameters": [
+                    {
+                        "description": "Remove member info",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.RemoveMemberRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/classroom/public": {
             "get": {
                 "description": "Retrieve all public classrooms",
@@ -2968,6 +3037,235 @@
                 }
             }
         },
+        "/submission": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new submission for an assignment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Create a new submission",
+                "parameters": [
+                    {
+                        "description": "Submission Data",
+                        "name": "submission",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateSubmissionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/submission/assignment/{assignment_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a submission for a specific assignment by assignment ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Get submission by assignment ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Assignment ID",
+                        "name": "assignment_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SubmissionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/submission/{submission_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve a submission by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Get submission by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Submission ID",
+                        "name": "submission_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.SubmissionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update an existing submission by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Update an existing submission",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Submission ID",
+                        "name": "submission_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated Submission Data",
+                        "name": "submission",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateSubmissionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "get": {
                 "security": [
@@ -3453,6 +3751,44 @@
                 }
             }
         },
+        "types.CreateSubmissionRequest": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "client_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "item_snapshot": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "playground_id": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "server_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "types.CreateUserRequest": {
             "type": "object",
             "required": [
@@ -3535,6 +3871,9 @@
                 "id": {
                     "type": "integer"
                 },
+                "join_at": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3597,6 +3936,21 @@
                 }
             }
         },
+        "types.RemoveMemberRequest": {
+            "type": "object",
+            "required": [
+                "class_id",
+                "user_id"
+            ],
+            "properties": {
+                "class_id": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.SignUpRequest": {
             "type": "object",
             "required": [
@@ -3612,6 +3966,56 @@
                 },
                 "password": {
                     "type": "string"
+                }
+            }
+        },
+        "types.SubmissionResponse": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "client_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "item_snapshot": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "playground_id": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "server_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -3774,6 +4178,44 @@
                     "type": "integer"
                 },
                 "topic": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UpdateSubmissionRequest": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "attempt_no": {
+                    "type": "integer"
+                },
+                "client_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "item_snapshot": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "playground_id": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "number"
+                },
+                "server_result": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "status": {
                     "type": "string"
                 }
             }

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -121,6 +121,32 @@ definitions:
     - description
     - topic
     type: object
+  types.CreateSubmissionRequest:
+    properties:
+      assignment_id:
+        type: integer
+      attempt_no:
+        type: integer
+      client_result:
+        additionalProperties: true
+        type: object
+      duration_ms:
+        type: integer
+      is_verified:
+        type: boolean
+      item_snapshot:
+        additionalProperties: true
+        type: object
+      playground_id:
+        type: integer
+      score:
+        type: number
+      server_result:
+        additionalProperties: true
+        type: object
+      status:
+        type: string
+    type: object
   types.CreateUserRequest:
     properties:
       email:
@@ -178,6 +204,8 @@ definitions:
         type: string
       id:
         type: integer
+      join_at:
+        type: string
       name:
         type: string
       picture_path:
@@ -220,6 +248,16 @@ definitions:
     - item
     - status
     type: object
+  types.RemoveMemberRequest:
+    properties:
+      class_id:
+        type: integer
+      user_id:
+        type: integer
+    required:
+    - class_id
+    - user_id
+    type: object
   types.SignUpRequest:
     properties:
       email:
@@ -231,6 +269,40 @@ definitions:
     required:
     - email
     - password
+    type: object
+  types.SubmissionResponse:
+    properties:
+      assignment_id:
+        type: integer
+      attempt_no:
+        type: integer
+      client_result:
+        additionalProperties: true
+        type: object
+      created_at:
+        type: string
+      duration_ms:
+        type: integer
+      id:
+        type: integer
+      is_verified:
+        type: boolean
+      item_snapshot:
+        additionalProperties: true
+        type: object
+      playground_id:
+        type: integer
+      score:
+        type: number
+      server_result:
+        additionalProperties: true
+        type: object
+      status:
+        type: string
+      updated_at:
+        type: string
+      user_id:
+        type: integer
     type: object
   types.TestCaseAssert:
     properties:
@@ -339,6 +411,32 @@ definitions:
         description: public or private
         type: integer
       topic:
+        type: string
+    type: object
+  types.UpdateSubmissionRequest:
+    properties:
+      assignment_id:
+        type: integer
+      attempt_no:
+        type: integer
+      client_result:
+        additionalProperties: true
+        type: object
+      duration_ms:
+        type: integer
+      is_verified:
+        type: boolean
+      item_snapshot:
+        additionalProperties: true
+        type: object
+      playground_id:
+        type: integer
+      score:
+        type: number
+      server_result:
+        additionalProperties: true
+        type: object
+      status:
         type: string
     type: object
   types.UpdateUserRequest:
@@ -1517,6 +1615,50 @@ paths:
       summary: Get all members of a class by class ID
       tags:
       - classrooms
+  /classroom/member:
+    delete:
+      consumes:
+      - application/json
+      description: Remove a member from a class
+      parameters:
+      - description: Remove member info
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/types.RemoveMemberRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Remove a member from a class
+      tags:
+      - classrooms
   /classroom/public:
     get:
       consumes:
@@ -2282,6 +2424,152 @@ paths:
       summary: Delete user profile
       tags:
       - profile
+  /submission:
+    post:
+      consumes:
+      - application/json
+      description: Create a new submission for an assignment
+      parameters:
+      - description: Submission Data
+        in: body
+        name: submission
+        required: true
+        schema:
+          $ref: '#/definitions/types.CreateSubmissionRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create a new submission
+      tags:
+      - Submission
+  /submission/{submission_id}:
+    get:
+      description: Retrieve a submission by its ID
+      parameters:
+      - description: Submission ID
+        in: path
+        name: submission_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.SubmissionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get submission by ID
+      tags:
+      - Submission
+    put:
+      consumes:
+      - application/json
+      description: Update an existing submission by its ID
+      parameters:
+      - description: Submission ID
+        in: path
+        name: submission_id
+        required: true
+        type: integer
+      - description: Updated Submission Data
+        in: body
+        name: submission
+        required: true
+        schema:
+          $ref: '#/definitions/types.UpdateSubmissionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update an existing submission
+      tags:
+      - Submission
+  /submission/assignment/{assignment_id}:
+    get:
+      description: Retrieve a submission for a specific assignment by assignment ID
+      parameters:
+      - description: Assignment ID
+        in: path
+        name: assignment_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.SubmissionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get submission by assignment ID
+      tags:
+      - Submission
   /user:
     get:
       consumes:

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -95,6 +95,10 @@ func (s *Server) Router() (http.Handler, func()) {
 	googleServiceUsecase := usecases.NewGoogleServiceUsecase(googleServiceRepository, oauthRepository)
 	googleServiceController := controller.NewGoogleServiceController(googleServiceUsecase)
 
+	submissionRepository := repository.NewSubmissionRepository(s.db)
+	submissionUsecase := usecases.NewSubmissionUseCase(submissionRepository)
+	submissionController := controller.NewSubmissionController(submissionUsecase)
+
 	api := r.Group("/api/v2")
 	{
 		oauthController.OAuthRegisterRoutes(api)
@@ -150,6 +154,10 @@ func (s *Server) Router() (http.Handler, func()) {
 		googleServiceGroup := api.Group("/google").Use(security.Middleware()).(*gin.RouterGroup)
 		{
 			googleServiceController.GoogleServiceRegisterRoutes(googleServiceGroup)
+		}
+		submissionGroup := api.Group("/submission").Use(security.Middleware()).(*gin.RouterGroup)
+		{
+			submissionController.SubmissionRoutes(submissionGroup)
 		}
 	}
 	if config.ENV == "dev" || config.ENV == "uat" {

--- a/internal/services/controller/class.controller.go
+++ b/internal/services/controller/class.controller.go
@@ -291,6 +291,33 @@ func (c *ClassController) ChangePermissionMember(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"message": "Member role updated successfully"})
 }
 
+// @Summary      Remove a member from a class
+// @Description  Remove a member from a class
+// @Tags         classrooms
+// @Accept       json
+// @Produce      json
+// @Param        body body types.RemoveMemberRequest true "Remove member info"
+// @Success      200   {object}  map[string]string
+// @Failure      400   {object}  map[string]string
+// @Failure      401   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /classroom/member [delete]
+func (c *ClassController) RemoveMemberInClass(ctx *gin.Context) {
+	var removeMemberReq types.RemoveMemberRequest
+	if err := ctx.ShouldBindJSON(&removeMemberReq); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	err := c.classUseCase.RemoveMemberInClassUseCases(ctx, removeMemberReq.ClassID, removeMemberReq.UserID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"message": "Member removed from class successfully"})
+}
+
 func (c *ClassController) ClassRoutes(r gin.IRoutes) {
 	r.POST("/", c.ClassCreateClass)
 	r.PUT("/:class_id", c.ClassUpdateClass)
@@ -298,6 +325,7 @@ func (c *ClassController) ClassRoutes(r gin.IRoutes) {
 	r.POST("/:class_id/join", c.JoinClass)
 	r.GET("/:class_id/members", c.GetAllMembersByClassID)
 	r.PUT("/:class_id/member/permission", c.ChangePermissionMember)
+	r.DELETE("/member", c.RemoveMemberInClass)
 }
 
 func (c *ClassController) ClassNotLoginRoutes(rg *gin.RouterGroup) {

--- a/internal/services/controller/submission.controller.go
+++ b/internal/services/controller/submission.controller.go
@@ -1,1 +1,179 @@
 package controller
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type SubmissionController struct {
+	submissionUseCase usecases.SubmissionUseCase
+}
+
+func NewSubmissionController(submissionUseCase usecases.SubmissionUseCase) *SubmissionController {
+	return &SubmissionController{
+		submissionUseCase: submissionUseCase,
+	}
+}
+
+// @Summary Create a new submission
+// @Description Create a new submission for an assignment
+// @Tags Submission
+// @Accept json
+// @Produce json
+// @Param submission body types.CreateSubmissionRequest true "Submission Data"
+// @Success 201 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security     BearerAuth
+// @Router /submission [post]
+func (c *SubmissionController) CreateSubmission(ctx *gin.Context) {
+	var req types.CreateSubmissionRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userIDVal, exist := ctx.Get("user_id")
+	if !exist {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	err := c.submissionUseCase.CreateSubmissionUseCase(ctx.Request.Context(), userID, req)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, gin.H{"message": "submission created successfully"})
+}
+
+// @Summary Update an existing submission
+// @Description Update an existing submission by its ID
+// @Tags Submission
+// @Accept json
+// @Produce json
+// @Param submission_id path int true "Submission ID"
+// @Param submission body types.UpdateSubmissionRequest true "Updated Submission Data"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security     BearerAuth
+// @Router /submission/{submission_id} [put]
+func (c *SubmissionController) UpdateSubmission(ctx *gin.Context) {
+	submissionIDStr := ctx.Param("submission_id")
+	submissionID, err := strconv.Atoi(submissionIDStr)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid submission ID"})
+		return
+	}
+
+	var req types.UpdateSubmissionRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userIDVal, exist := ctx.Get("user_id")
+	if !exist {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	err = c.submissionUseCase.UpdateSubmissionUseCase(ctx.Request.Context(), userID, submissionID, req)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "submission updated successfully"})
+}
+
+// @Summary Get submission by assignment ID
+// @Description Retrieve a submission for a specific assignment by assignment ID
+// @Tags Submission
+// @Produce json
+// @Param assignment_id path int true "Assignment ID"
+// @Success 200 {object} types.SubmissionResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security     BearerAuth
+// @Router /submission/assignment/{assignment_id} [get]
+func (c *SubmissionController) GetAllSubmissionByAssignmentID(ctx *gin.Context) {
+	assignmentIDStr := ctx.Param("assignment_id")
+	assignmentID, err := strconv.Atoi(assignmentIDStr)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid assignment ID"})
+		return
+	}
+
+	ownerID, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	ownerIDInt, ok := ownerID.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	submissionResponse, err := c.submissionUseCase.GetAllSubmissionByAssignmentIDUseCase(ctx.Request.Context(), ownerIDInt, assignmentID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, submissionResponse)
+}
+
+// @Summary Get submission by ID
+// @Description Retrieve a submission by its ID
+// @Tags Submission
+// @Produce json
+// @Param submission_id path int true "Submission ID"
+// @Success 200 {object} types.SubmissionResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security     BearerAuth
+// @Router /submission/{submission_id} [get]
+func (c *SubmissionController) GetSubmissionByID(ctx *gin.Context) {
+	submissionIDStr := ctx.Param("submission_id")
+	submissionID, err := strconv.Atoi(submissionIDStr)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid submission ID"})
+		return
+	}
+
+	submissionResponse, err := c.submissionUseCase.GetSubmissionByIDUseCase(ctx.Request.Context(), submissionID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, submissionResponse)
+}
+
+func (c *SubmissionController) SubmissionRoutes(r gin.IRoutes) {
+	r.POST("/", c.CreateSubmission)
+	r.PUT("/:submission_id", c.UpdateSubmission)
+	r.GET("/assignment/:assignment_id", c.GetAllSubmissionByAssignmentID)
+	r.GET("/:submission_id", c.GetSubmissionByID)
+}

--- a/internal/services/repository/class.repository.go
+++ b/internal/services/repository/class.repository.go
@@ -20,6 +20,7 @@ type ClassRepository interface {
 	GetAllMembersByClassID(ctx context.Context, classID int) (*[]types.MemberResponse, error)
 	GetAllClassPublic(ctx context.Context) (*[]types.ClassResponse, error)
 	ChangePermissionMember(ctx context.Context, userID, classID int, newRole string) error
+	RemoveMemberInClass(ctx context.Context, classID, userID int) error
 }
 
 type classRepository struct {
@@ -302,6 +303,23 @@ func (r *classRepository) ChangePermissionMember(ctx context.Context, userID, cl
 	member.Role = newRole
 
 	if err := r.db.WithContext(ctx).Save(&member).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *classRepository) RemoveMemberInClass(ctx context.Context, classID, userID int) error {
+	var member model.Member
+	err := r.db.WithContext(ctx).Where("user_id = ? AND class_id = ?", userID, classID).First(&member).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return gorm.ErrRecordNotFound
+		}
+		return err
+	}
+
+	if err := r.db.WithContext(ctx).Delete(&member).Error; err != nil {
 		return err
 	}
 

--- a/internal/services/repository/submission.repository.go
+++ b/internal/services/repository/submission.repository.go
@@ -1,11 +1,20 @@
 package repository
 
 import (
+	"context"
+	"encoding/json"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/model"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
 type SubmissionRepository interface {
-	// CreateSubmission(ctx context.Context, )
+	CreateSubmission(ctx context.Context, userId int, request types.CreateSubmissionRequest) error
+	UpdateSubmission(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error
+	GetAllSubmissionByAssignmentID(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error)
+	GetSubmissionByID(ctx context.Context, submissionID int) (*types.SubmissionResponse, error)
 }
 
 type submissionRepository struct {
@@ -14,4 +23,189 @@ type submissionRepository struct {
 
 func NewSubmissionRepository(db *gorm.DB) SubmissionRepository {
 	return &submissionRepository{db: db}
+}
+
+func (r *submissionRepository) CreateSubmission(ctx context.Context, userId int, request types.CreateSubmissionRequest) error {
+	var user model.User
+	err := r.db.WithContext(ctx).Where("id = ?", userId).First(&user).Error
+	if err != nil {
+		return err
+	}
+
+	var assignment model.Assignment
+	err = r.db.WithContext(ctx).Where("id = ?", request.AssignmentID).First(&assignment).Error
+	if err != nil {
+		return err
+	}
+
+	var playground model.Playground
+	err = r.db.WithContext(ctx).Where("id = ?", request.PlaygroundID).First(&playground).Error
+	if err != nil {
+		return err
+	}
+
+	snapshot, _ := json.Marshal(request.ItemSnapshot)
+	clientResult, _ := json.Marshal(request.ClientResult)
+	serverResult, _ := json.Marshal(request.ServerResult)
+
+	newSubmission := model.Submission{
+		AssignmentID:  int(request.AssignmentID),
+		UserID:        int(userId),
+		PlaygroundID:  int(request.PlaygroundID),
+		AttemptNumber: int(request.AttemptNumber),
+		ItemSnapshot:  datatypes.JSON(snapshot),
+		ClientResult:  datatypes.JSON(clientResult),
+		ServerResult:  datatypes.JSON(serverResult),
+		Score:         request.Score,
+		Status:        request.Status,
+		IsVerified:    request.IsVerified,
+		DurationMS:    request.DurationMS,
+	}
+	if err := r.db.WithContext(ctx).Create(&newSubmission).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *submissionRepository) UpdateSubmission(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error {
+	var submission model.Submission
+	err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", submissionID, userID).First(&submission).Error
+	if err != nil {
+		return err
+	}
+
+	snapshot, _ := json.Marshal(request.ItemSnapshot)
+	clientResult, _ := json.Marshal(request.ClientResult)
+	serverResult, _ := json.Marshal(request.ServerResult)
+
+	submission.AttemptNumber = int(request.AttemptNumber)
+	submission.ItemSnapshot = datatypes.JSON(snapshot)
+	submission.ClientResult = datatypes.JSON(clientResult)
+	submission.ServerResult = datatypes.JSON(serverResult)
+	submission.Score = request.Score
+	submission.Status = request.Status
+	submission.IsVerified = request.IsVerified
+	submission.DurationMS = request.DurationMS
+
+	if err := r.db.WithContext(ctx).Save(&submission).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *submissionRepository) GetAllSubmissionByAssignmentID(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error) {
+	var submission []model.Submission
+	err := r.db.WithContext(ctx).Where("assignment_id = ?", assignmentID).Find(&submission).Error
+	if err != nil {
+		return nil, err
+	}
+
+	var user model.User
+	if err := r.db.WithContext(ctx).Where("id = ?", ownerID).First(&user).Error; err != nil {
+		return nil, err
+	}
+
+	// Select * FROM classroom c JOIN assignment a ON a.class_id = c.id WHERE a.id = ? AND c.owner_id = ?
+	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Where("a.id = ? AND c.owner_id = ?", assignmentID, ownerID).First(&model.Classroom{}).Error
+	if err != nil {
+		return nil, err
+	}
+
+	submissionResponse := make([]types.SubmissionResponse, 0, len(submission))
+
+	for _, sub := range submission {
+		var ItemSnapshot map[string]interface{}
+		if len(sub.ItemSnapshot) > 0 {
+			if err := json.Unmarshal(sub.ItemSnapshot, &ItemSnapshot); err != nil {
+				return nil, err
+			}
+		} else {
+			ItemSnapshot = map[string]interface{}{}
+		}
+
+		var ClientResult map[string]interface{}
+		if len(sub.ClientResult) > 0 {
+			if err := json.Unmarshal(sub.ClientResult, &ClientResult); err != nil {
+				return nil, err
+			}
+		} else {
+			ClientResult = map[string]interface{}{}
+		}
+
+		var ServerResult map[string]interface{}
+		if len(sub.ServerResult) > 0 {
+			if err := json.Unmarshal(sub.ServerResult, &ServerResult); err != nil {
+				return nil, err
+			}
+		} else {
+			ServerResult = map[string]interface{}{}
+		}
+
+		submissionResponse = append(submissionResponse, types.SubmissionResponse{
+			ID:            int(sub.ID),
+			AssignmentID:  sub.AssignmentID,
+			UserID:        sub.UserID,
+			PlaygroundID:  sub.PlaygroundID,
+			AttemptNumber: sub.AttemptNumber,
+			ItemSnapshot:  ItemSnapshot,
+			ClientResult:  ClientResult,
+			ServerResult:  ServerResult,
+			Score:         sub.Score,
+			Status:        sub.Status,
+			IsVerified:    sub.IsVerified,
+			DurationMS:    sub.DurationMS,
+		})
+	}
+	return &submissionResponse, nil
+}
+
+func (r *submissionRepository) GetSubmissionByID(ctx context.Context, submissionID int) (*types.SubmissionResponse, error) {
+	var submission model.Submission
+	err := r.db.WithContext(ctx).Where("id = ?", submissionID).First(&submission).Error
+	if err != nil {
+		return nil, err
+	}
+
+	var ItemSnapshot map[string]interface{}
+	if len(submission.ItemSnapshot) > 0 {
+		if err := json.Unmarshal(submission.ItemSnapshot, &ItemSnapshot); err != nil {
+			return nil, err
+		}
+	} else {
+		ItemSnapshot = map[string]interface{}{}
+	}
+
+	var ClientResult map[string]interface{}
+	if len(submission.ClientResult) > 0 {
+		if err := json.Unmarshal(submission.ClientResult, &ClientResult); err != nil {
+			return nil, err
+		}
+	} else {
+		ClientResult = map[string]interface{}{}
+	}
+
+	var ServerResult map[string]interface{}
+	if len(submission.ServerResult) > 0 {
+		if err := json.Unmarshal(submission.ServerResult, &ServerResult); err != nil {
+			return nil, err
+		}
+	} else {
+		ServerResult = map[string]interface{}{}
+	}
+
+	submissionResponse := &types.SubmissionResponse{
+		ID:            int(submission.ID),
+		AssignmentID:  submission.AssignmentID,
+		UserID:        submission.UserID,
+		PlaygroundID:  submission.PlaygroundID,
+		AttemptNumber: submission.AttemptNumber,
+		ItemSnapshot:  ItemSnapshot,
+		ClientResult:  ClientResult,
+		ServerResult:  ServerResult,
+		Score:         submission.Score,
+		Status:        submission.Status,
+		IsVerified:    submission.IsVerified,
+		DurationMS:    submission.DurationMS,
+	}
+	return submissionResponse, nil
 }

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -359,15 +359,56 @@ type CourseWorkListResponse struct {
 	CourseWork []CourseWorkData `json:"courseWork"`
 }
 
-type CreateSubmissionRequest struct {
-	AssignmentID int `json:"assignment_id" binding:"required"`
-	UserID       int `json:"user_id" binding:"required"`
-	PlaygroundID int `json:"playground_id" binding:"required"`
-	AttemptNO    int
-}
-
 type NewRoleRequest struct {
 	ClassID int    `json:"class_id" binding:"required"`
 	UserID  int    `json:"user_id" binding:"required"`
 	NewRole string `json:"new_role" binding:"required"`
+}
+
+type RemoveMemberRequest struct {
+	ClassID int `json:"class_id" binding:"required"`
+	UserID  int `json:"user_id" binding:"required"`
+}
+
+type CreateSubmissionRequest struct {
+	AssignmentID  int                    `json:"assignment_id"`
+	PlaygroundID  int                    `json:"playground_id"`
+	AttemptNumber int                    `json:"attempt_no"`
+	ItemSnapshot  map[string]interface{} `json:"item_snapshot"`
+	ClientResult  map[string]interface{} `json:"client_result"`
+	ServerResult  map[string]interface{} `json:"server_result"`
+	Score         float64                `json:"score"`
+	Status        string                 `json:"status"`
+	IsVerified    bool                   `json:"is_verified"`
+	DurationMS    int                    `json:"duration_ms"`
+}
+
+type UpdateSubmissionRequest struct {
+	AssignmentID  int                    `json:"assignment_id"`
+	PlaygroundID  int                    `json:"playground_id"`
+	AttemptNumber int                    `json:"attempt_no"`
+	ItemSnapshot  map[string]interface{} `json:"item_snapshot"`
+	ClientResult  map[string]interface{} `json:"client_result"`
+	ServerResult  map[string]interface{} `json:"server_result"`
+	Score         float64                `json:"score"`
+	Status        string                 `json:"status"`
+	IsVerified    bool                   `json:"is_verified"`
+	DurationMS    int                    `json:"duration_ms"`
+}
+
+type SubmissionResponse struct {
+	ID            int                    `json:"id"`
+	AssignmentID  int                    `json:"assignment_id"`
+	UserID        int                    `json:"user_id"`
+	PlaygroundID  int                    `json:"playground_id"`
+	AttemptNumber int                    `json:"attempt_no"`
+	ItemSnapshot  map[string]interface{} `json:"item_snapshot"`
+	ClientResult  map[string]interface{} `json:"client_result"`
+	ServerResult  map[string]interface{} `json:"server_result"`
+	Score         float64                `json:"score"`
+	Status        string                 `json:"status"`
+	IsVerified    bool                   `json:"is_verified"`
+	DurationMS    int                    `json:"duration_ms"`
+	CreatedAt     string                 `json:"created_at"`
+	UpdatedAt     string                 `json:"updated_at"`
 }

--- a/internal/services/usecases/class.usecases.go
+++ b/internal/services/usecases/class.usecases.go
@@ -18,6 +18,7 @@ type ClassUseCase interface {
 	GetAllMembersByClassID(ctx context.Context, classID int) (*[]types.MemberResponse, error)
 	GetAllClassPublicUseCases(ctx context.Context) (*[]types.ClassResponse, error)
 	ChangePermissionMemberUseCases(ctx context.Context, userID, classID int, newRole string) error
+	RemoveMemberInClassUseCases(ctx context.Context, classID, userID int) error
 }
 
 type classUseCase struct {
@@ -94,6 +95,14 @@ func (uc *classUseCase) GetAllClassPublicUseCases(ctx context.Context) (*[]types
 
 func (uc *classUseCase) ChangePermissionMemberUseCases(ctx context.Context, userID, classID int, newRole string) error {
 	err := uc.classRepo.ChangePermissionMember(ctx, userID, classID, newRole)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (uc *classUseCase) RemoveMemberInClassUseCases(ctx context.Context, classID, userID int) error {
+	err := uc.classRepo.RemoveMemberInClass(ctx, classID, userID)
 	if err != nil {
 		return err
 	}

--- a/internal/services/usecases/submission.usecases.go
+++ b/internal/services/usecases/submission.usecases.go
@@ -1,2 +1,55 @@
 package usecases
- 
+
+import (
+	"context"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/repository"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+)
+
+type SubmissionUseCase interface {
+	CreateSubmissionUseCase(ctx context.Context, userId int, request types.CreateSubmissionRequest) error
+	UpdateSubmissionUseCase(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error
+	GetAllSubmissionByAssignmentIDUseCase(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error)
+	GetSubmissionByIDUseCase(ctx context.Context, submissionID int) (*types.SubmissionResponse, error)
+}
+
+type submissionUseCase struct {
+	submissionRepo repository.SubmissionRepository
+}
+
+func NewSubmissionUseCase(submissionRepo repository.SubmissionRepository) SubmissionUseCase {
+	return &submissionUseCase{submissionRepo: submissionRepo}
+}
+
+func (uc *submissionUseCase) CreateSubmissionUseCase(ctx context.Context, userId int, request types.CreateSubmissionRequest) error {
+	err := uc.submissionRepo.CreateSubmission(ctx, userId, request)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (uc *submissionUseCase) UpdateSubmissionUseCase(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error {
+	err := uc.submissionRepo.UpdateSubmission(ctx, userID, submissionID, request)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (uc *submissionUseCase) GetAllSubmissionByAssignmentIDUseCase(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error) {
+	resp, err := uc.submissionRepo.GetAllSubmissionByAssignmentID(ctx, ownerID, assignmentID)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (uc *submissionUseCase) GetSubmissionByIDUseCase(ctx context.Context, submissionID int) (*types.SubmissionResponse, error) {
+	resp, err := uc.submissionRepo.GetSubmissionByID(ctx, submissionID)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}


### PR DESCRIPTION
This pull request introduces a new "Submission" feature to the API and adds support for removing classroom members. The changes include new API endpoints, controller logic, repository methods, and updates to the Swagger documentation. The most important changes are grouped below:

**Submission Feature:**

* Added new API endpoints for creating, updating, and retrieving submissions by ID and assignment ID in `cmd/api/docs/swagger.yaml` and registered corresponding routes in `internal/server/routes.go`. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R2427-R2572) [[2]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R158-R161)
* Implemented `SubmissionController` with methods for handling submission-related requests, including creation, update, and retrieval, in `internal/services/controller/submission.controller.go`.
* Defined repository interface and methods for submissions, including create, update, and fetch operations, in `internal/services/repository/submission.repository.go`.
* Added Swagger definitions for submission requests and responses in `cmd/api/docs/swagger.yaml`. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R124-R149) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R273-R306) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R416-R441)

**Classroom Member Removal:**

* Added API endpoint and controller logic for removing a member from a class, including repository support and Swagger documentation, in `cmd/api/docs/swagger.yaml`, `internal/services/controller/class.controller.go`, and `internal/services/repository/class.repository.go`. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R251-R260) [[2]](diffhunk://#diff-312f103cc6498df23dd657232f82e766711960309cb0f6e681dad28b590ac0a5R294-R328) [[3]](diffhunk://#diff-9b65bdab48d4161553756c87c8684090c222b3b891e34c13f8517b72da6c92f5R23) [[4]](diffhunk://#diff-9b65bdab48d4161553756c87c8684090c222b3b891e34c13f8517b72da6c92f5R311-R327)

**Other Updates:**

* Updated member response definition to include `join_at` property in Swagger documentation.
* Registered new submission routes in the main server router setup.

These changes collectively introduce robust submission management and classroom member removal functionalities to the backend API.