### PR TITLE
fix handler api submission

### DIFF
--- a/internal/services/controller/submission.controller.go
+++ b/internal/services/controller/submission.controller.go
@@ -78,12 +78,6 @@ func (c *SubmissionController) UpdateSubmission(ctx *gin.Context) {
 		return
 	}
 
-	var req types.UpdateSubmissionRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
 	userIDVal, exist := ctx.Get("user_id")
 	if !exist {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
@@ -93,6 +87,12 @@ func (c *SubmissionController) UpdateSubmission(ctx *gin.Context) {
 	userID, ok := userIDVal.(int)
 	if !ok {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	var req types.UpdateSubmissionRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -162,7 +162,19 @@ func (c *SubmissionController) GetSubmissionByID(ctx *gin.Context) {
 		return
 	}
 
-	submissionResponse, err := c.submissionUseCase.GetSubmissionByIDUseCase(ctx.Request.Context(), submissionID)
+	userIDVal, exist := ctx.Get("user_id")
+	if !exist {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	submissionResponse, err := c.submissionUseCase.GetSubmissionByIDUseCase(ctx.Request.Context(), userID, submissionID)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/services/repository/submission.repository.go
+++ b/internal/services/repository/submission.repository.go
@@ -14,7 +14,7 @@ type SubmissionRepository interface {
 	CreateSubmission(ctx context.Context, userId int, request types.CreateSubmissionRequest) error
 	UpdateSubmission(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error
 	GetAllSubmissionByAssignmentID(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error)
-	GetSubmissionByID(ctx context.Context, submissionID int) (*types.SubmissionResponse, error)
+	GetSubmissionByID(ctx context.Context, userID, submissionID int) (*types.SubmissionResponse, error)
 }
 
 type submissionRepository struct {
@@ -69,7 +69,14 @@ func (r *submissionRepository) CreateSubmission(ctx context.Context, userId int,
 
 func (r *submissionRepository) UpdateSubmission(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error {
 	var submission model.Submission
-	err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", submissionID, userID).First(&submission).Error
+	err := r.db.WithContext(ctx).Where("id = ?", submissionID, userID).First(&submission).Error
+	if err != nil {
+		return err
+	}
+
+	// อนุญาตให้แก้ไขได้ทุกฟิลด์ เจ้าของ submission และ owner ของ assignment และ member ที่เป็น TA เท่านั้น
+	// Select * FROM classroom c JOIN assignment a ON a.class_id = c.id JOIN member m ON m.class_id = c.id WHERE a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?))
+	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Joins("JOIN member m ON m.class_id = c.id").Joins("JOIN submission s ON s.assignment_id = a.id").Where("a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?) OR s.user_id = ?)", submission.AssignmentID, userID, userID, "ta", userID).First(&model.Classroom{}).Error
 	if err != nil {
 		return err
 	}
@@ -105,8 +112,9 @@ func (r *submissionRepository) GetAllSubmissionByAssignmentID(ctx context.Contex
 		return nil, err
 	}
 
-	// Select * FROM classroom c JOIN assignment a ON a.class_id = c.id WHERE a.id = ? AND c.owner_id = ?
-	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Where("a.id = ? AND c.owner_id = ?", assignmentID, ownerID).First(&model.Classroom{}).Error
+	// อนุญาตให้แก้ไขได้ทุกฟิลด์ เจ้าของ submission และ owner ของ assignment และ member ที่เป็น TA เท่านั้น
+	// Select * FROM classroom c JOIN assignment a ON a.class_id = c.id JOIN member m ON m.class_id = c.id WHERE a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?))
+	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Joins("JOIN member m ON m.class_id = c.id").Where("a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?))", assignmentID, ownerID, ownerID, "ta").First(&model.Classroom{}).Error
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +167,16 @@ func (r *submissionRepository) GetAllSubmissionByAssignmentID(ctx context.Contex
 	return &submissionResponse, nil
 }
 
-func (r *submissionRepository) GetSubmissionByID(ctx context.Context, submissionID int) (*types.SubmissionResponse, error) {
+func (r *submissionRepository) GetSubmissionByID(ctx context.Context, userID, submissionID int) (*types.SubmissionResponse, error) {
 	var submission model.Submission
 	err := r.db.WithContext(ctx).Where("id = ?", submissionID).First(&submission).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// อนุญาตให้แก้ไขได้ทุกฟิลด์ เจ้าของ submission และ owner ของ assignment และ member ที่เป็น TA เท่านั้น
+	// Select * FROM classroom c JOIN assignment a ON a.class_id = c.id JOIN member m ON m.class_id = c.id WHERE a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?))
+	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Joins("JOIN member m ON m.class_id = c.id").Joins("JOIN submission s ON s.assignment_id = a.id").Where("a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?) OR s.user_id = ?)", submission.AssignmentID, userID, userID, "ta", userID).First(&model.Classroom{}).Error
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/usecases/submission.usecases.go
+++ b/internal/services/usecases/submission.usecases.go
@@ -11,7 +11,7 @@ type SubmissionUseCase interface {
 	CreateSubmissionUseCase(ctx context.Context, userId int, request types.CreateSubmissionRequest) error
 	UpdateSubmissionUseCase(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error
 	GetAllSubmissionByAssignmentIDUseCase(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error)
-	GetSubmissionByIDUseCase(ctx context.Context, submissionID int) (*types.SubmissionResponse, error)
+	GetSubmissionByIDUseCase(ctx context.Context, userID, submissionID int) (*types.SubmissionResponse, error)
 }
 
 type submissionUseCase struct {
@@ -46,8 +46,8 @@ func (uc *submissionUseCase) GetAllSubmissionByAssignmentIDUseCase(ctx context.C
 	return resp, nil
 }
 
-func (uc *submissionUseCase) GetSubmissionByIDUseCase(ctx context.Context, submissionID int) (*types.SubmissionResponse, error) {
-	resp, err := uc.submissionRepo.GetSubmissionByID(ctx, submissionID)
+func (uc *submissionUseCase) GetSubmissionByIDUseCase(ctx context.Context, userID, submissionID int) (*types.SubmissionResponse, error) {
+	resp, err := uc.submissionRepo.GetSubmissionByID(ctx, userID, submissionID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request enhances authorization checks for submission-related operations to ensure that only authorized users (submission owners, assignment owners, or TAs) can access or modify submissions. The changes update the controller, use case, and repository layers to consistently require and validate the user ID for sensitive operations.

**Authorization and Access Control Improvements:**

* The `GetSubmissionByID` and `UpdateSubmission` controller methods now extract and validate the `user_id` from the request context, returning an error if the user is unauthorized or if the user ID is invalid. [[1]](diffhunk://#diff-66cec1047ab1a45f037ce70fd8aab601751f891bb803a98880d8f9552ac9b30bL81-L86) [[2]](diffhunk://#diff-66cec1047ab1a45f037ce70fd8aab601751f891bb803a98880d8f9552ac9b30bR93-R98) [[3]](diffhunk://#diff-66cec1047ab1a45f037ce70fd8aab601751f891bb803a98880d8f9552ac9b30bL165-R177)
* The `GetSubmissionByIDUseCase` and repository method signatures now require a `userID` argument, ensuring that authorization checks are enforced at all layers. [[1]](diffhunk://#diff-0a0102789baaf1fa3df60e3425c1e97f51b4d84b50e8ba28853e8433ad55ed18L14-R14) [[2]](diffhunk://#diff-0a0102789baaf1fa3df60e3425c1e97f51b4d84b50e8ba28853e8433ad55ed18L49-R50) [[3]](diffhunk://#diff-ade6bad4c69d98b8e761d85a9d2103a236e10ca574514f3a8a7cecce442ae420L17-R17) [[4]](diffhunk://#diff-ade6bad4c69d98b8e761d85a9d2103a236e10ca574514f3a8a7cecce442ae420L162-R183)

**Repository Query Enhancements:**

* Authorization logic in repository methods has been updated to allow access only to submission owners, assignment owners, or TAs. The relevant SQL queries now join additional tables and check user roles more thoroughly. [[1]](diffhunk://#diff-ade6bad4c69d98b8e761d85a9d2103a236e10ca574514f3a8a7cecce442ae420L72-R79) [[2]](diffhunk://#diff-ade6bad4c69d98b8e761d85a9d2103a236e10ca574514f3a8a7cecce442ae420L108-R117) [[3]](diffhunk://#diff-ade6bad4c69d98b8e761d85a9d2103a236e10ca574514f3a8a7cecce442ae420L162-R183)