### PR TITLE
Dev

### DIFF
--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -135,6 +135,169 @@ const docTemplate = `{
                 }
             }
         },
+        "/bookmark": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all bookmarks for a user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmark"
+                ],
+                "summary": "Get bookmarks by user ID",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a bookmark for a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmark"
+                ],
+                "summary": "Create a bookmark",
+                "parameters": [
+                    {
+                        "description": "Bookmark data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.BookMarkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a bookmark for a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmark"
+                ],
+                "summary": "Delete a bookmark",
+                "parameters": [
+                    {
+                        "description": "Bookmark data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.BookMarkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/classroom": {
             "get": {
                 "description": "Retrieve all classrooms",
@@ -3991,6 +4154,17 @@ const docTemplate = `{
                 }
             }
         },
+        "types.BookMarkRequest": {
+            "type": "object",
+            "required": [
+                "class_id"
+            ],
+            "properties": {
+                "class_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.ChangePasswordRequest": {
             "type": "object",
             "required": [
@@ -4488,9 +4662,6 @@ const docTemplate = `{
                 },
                 "class_id": {
                     "type": "integer"
-                },
-                "class_topic": {
-                    "type": "string"
                 },
                 "description": {
                     "type": "string"

--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -3843,6 +3843,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/submission/{submission_id}/grade": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the grade for a specific submission by submission ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Update grade for a submission",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Submission ID",
+                        "name": "submission_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated Grade Data",
+                        "name": "grade",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateGradeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "get": {
                 "security": [
@@ -4407,6 +4474,9 @@ const docTemplate = `{
                 "duration_ms": {
                     "type": "integer"
                 },
+                "feed_back": {
+                    "type": "string"
+                },
                 "is_verified": {
                     "type": "boolean"
                 },
@@ -4911,6 +4981,24 @@ const docTemplate = `{
                 }
             }
         },
+        "types.UpdateGradeRequest": {
+            "type": "object",
+            "required": [
+                "is_verified",
+                "score"
+            ],
+            "properties": {
+                "feed_back": {
+                    "type": "string"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "score": {
+                    "type": "number"
+                }
+            }
+        },
         "types.UpdateSubmissionRequest": {
             "type": "object",
             "properties": {
@@ -4926,6 +5014,9 @@ const docTemplate = `{
                 },
                 "duration_ms": {
                     "type": "integer"
+                },
+                "feed_back": {
+                    "type": "string"
                 },
                 "is_verified": {
                     "type": "boolean"

--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -3751,6 +3751,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/user/me/task": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve tasks of the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get my tasks",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TaskMeResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user/owner/classroom": {
             "get": {
                 "security": [
@@ -4063,9 +4103,6 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
-                "due_date": {
-                    "type": "string"
-                },
                 "grade": {
                     "description": "total grade of the assignment",
                     "type": "integer"
@@ -4178,6 +4215,9 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
+                "due_date": {
+                    "type": "string"
+                },
                 "grade": {
                     "description": "total grade of the assignment",
                     "type": "integer"
@@ -4186,7 +4226,6 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "setting": {
-                    "description": "Setting     AssignmentSettings  ` + "`" + `json:\"settings\"` + "`" + `\nCondition   AssignmentCondition ` + "`" + `json:\"condition\"` + "`" + `",
                     "type": "object",
                     "additionalProperties": true
                 },
@@ -4432,6 +4471,42 @@ const docTemplate = `{
                 },
                 "user_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "types.TaskMeResponse": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "assignment_title": {
+                    "type": "string"
+                },
+                "banner_id": {
+                    "type": "integer"
+                },
+                "class_id": {
+                    "type": "integer"
+                },
+                "class_topic": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "due_date": {
+                    "type": "string"
+                },
+                "favorite": {
+                    "type": "integer"
+                },
+                "max_attempt": {
+                    "type": "integer"
+                },
+                "status": {
+                    "description": "e.g., \"not_started\", \"in_progress\", \"completed\", \"overdue\"",
+                    "type": "string"
                 }
             }
         },

--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -4963,6 +4963,9 @@ const docTemplate = `{
         "types.UpdateClassRequest": {
             "type": "object",
             "properties": {
+                "banner_id": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },

--- a/cmd/api/docs/docs.go
+++ b/cmd/api/docs/docs.go
@@ -400,6 +400,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/classroom/join-with-code/{code}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Join a class using a unique code",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "classrooms"
+                ],
+                "summary": "Join a class with code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Class Code",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/classroom/member": {
             "delete": {
                 "security": [

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -3835,6 +3835,73 @@
                 }
             }
         },
+        "/submission/{submission_id}/grade": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the grade for a specific submission by submission ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Submission"
+                ],
+                "summary": "Update grade for a submission",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Submission ID",
+                        "name": "submission_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated Grade Data",
+                        "name": "grade",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateGradeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "get": {
                 "security": [
@@ -4399,6 +4466,9 @@
                 "duration_ms": {
                     "type": "integer"
                 },
+                "feed_back": {
+                    "type": "string"
+                },
                 "is_verified": {
                     "type": "boolean"
                 },
@@ -4903,6 +4973,24 @@
                 }
             }
         },
+        "types.UpdateGradeRequest": {
+            "type": "object",
+            "required": [
+                "is_verified",
+                "score"
+            ],
+            "properties": {
+                "feed_back": {
+                    "type": "string"
+                },
+                "is_verified": {
+                    "type": "boolean"
+                },
+                "score": {
+                    "type": "number"
+                }
+            }
+        },
         "types.UpdateSubmissionRequest": {
             "type": "object",
             "properties": {
@@ -4918,6 +5006,9 @@
                 },
                 "duration_ms": {
                     "type": "integer"
+                },
+                "feed_back": {
+                    "type": "string"
                 },
                 "is_verified": {
                     "type": "boolean"

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -4955,6 +4955,9 @@
         "types.UpdateClassRequest": {
             "type": "object",
             "properties": {
+                "banner_id": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -392,6 +392,73 @@
                 }
             }
         },
+        "/classroom/join-with-code/{code}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Join a class using a unique code",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "classrooms"
+                ],
+                "summary": "Join a class with code",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Class Code",
+                        "name": "code",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/classroom/member": {
             "delete": {
                 "security": [

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -3743,6 +3743,46 @@
                 }
             }
         },
+        "/user/me/task": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieve tasks of the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get my tasks",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TaskMeResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user/owner/classroom": {
             "get": {
                 "security": [
@@ -4055,9 +4095,6 @@
                 "description": {
                     "type": "string"
                 },
-                "due_date": {
-                    "type": "string"
-                },
                 "grade": {
                     "description": "total grade of the assignment",
                     "type": "integer"
@@ -4170,6 +4207,9 @@
                 "description": {
                     "type": "string"
                 },
+                "due_date": {
+                    "type": "string"
+                },
                 "grade": {
                     "description": "total grade of the assignment",
                     "type": "integer"
@@ -4178,7 +4218,6 @@
                     "type": "integer"
                 },
                 "setting": {
-                    "description": "Setting     AssignmentSettings  `json:\"settings\"`\nCondition   AssignmentCondition `json:\"condition\"`",
                     "type": "object",
                     "additionalProperties": true
                 },
@@ -4424,6 +4463,42 @@
                 },
                 "user_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "types.TaskMeResponse": {
+            "type": "object",
+            "properties": {
+                "assignment_id": {
+                    "type": "integer"
+                },
+                "assignment_title": {
+                    "type": "string"
+                },
+                "banner_id": {
+                    "type": "integer"
+                },
+                "class_id": {
+                    "type": "integer"
+                },
+                "class_topic": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "due_date": {
+                    "type": "string"
+                },
+                "favorite": {
+                    "type": "integer"
+                },
+                "max_attempt": {
+                    "type": "integer"
+                },
+                "status": {
+                    "description": "e.g., \"not_started\", \"in_progress\", \"completed\", \"overdue\"",
+                    "type": "string"
                 }
             }
         },

--- a/cmd/api/docs/swagger.json
+++ b/cmd/api/docs/swagger.json
@@ -127,6 +127,169 @@
                 }
             }
         },
+        "/bookmark": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all bookmarks for a user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmark"
+                ],
+                "summary": "Get bookmarks by user ID",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a bookmark for a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmark"
+                ],
+                "summary": "Create a bookmark",
+                "parameters": [
+                    {
+                        "description": "Bookmark data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.BookMarkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a bookmark for a class",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmark"
+                ],
+                "summary": "Delete a bookmark",
+                "parameters": [
+                    {
+                        "description": "Bookmark data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.BookMarkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/classroom": {
             "get": {
                 "description": "Retrieve all classrooms",
@@ -3983,6 +4146,17 @@
                 }
             }
         },
+        "types.BookMarkRequest": {
+            "type": "object",
+            "required": [
+                "class_id"
+            ],
+            "properties": {
+                "class_id": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.ChangePasswordRequest": {
             "type": "object",
             "required": [
@@ -4480,9 +4654,6 @@
                 },
                 "class_id": {
                     "type": "integer"
-                },
-                "class_topic": {
-                    "type": "string"
                 },
                 "description": {
                     "type": "string"

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -95,8 +95,6 @@ definitions:
         type: object
       description:
         type: string
-      due_date:
-        type: string
       grade:
         description: total grade of the assignment
         type: integer
@@ -175,6 +173,8 @@ definitions:
         type: object
       description:
         type: string
+      due_date:
+        type: string
       grade:
         description: total grade of the assignment
         type: integer
@@ -182,9 +182,6 @@ definitions:
         type: integer
       setting:
         additionalProperties: true
-        description: |-
-          Setting     AssignmentSettings  `json:"settings"`
-          Condition   AssignmentCondition `json:"condition"`
         type: object
       title:
         type: string
@@ -350,6 +347,30 @@ definitions:
         type: string
       user_id:
         type: integer
+    type: object
+  types.TaskMeResponse:
+    properties:
+      assignment_id:
+        type: integer
+      assignment_title:
+        type: string
+      banner_id:
+        type: integer
+      class_id:
+        type: integer
+      class_topic:
+        type: string
+      description:
+        type: string
+      due_date:
+        type: string
+      favorite:
+        type: integer
+      max_attempt:
+        type: integer
+      status:
+        description: e.g., "not_started", "in_progress", "completed", "overdue"
+        type: string
     type: object
   types.TestCaseAssert:
     properties:
@@ -3000,6 +3021,31 @@ paths:
       security:
       - BearerAuth: []
       summary: Get my classes
+      tags:
+      - users
+  /user/me/task:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve tasks of the authenticated user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.TaskMeResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get my tasks
       tags:
       - users
   /user/owner/classroom:

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -1792,6 +1792,49 @@ paths:
       summary: Get all members of a class by class ID
       tags:
       - classrooms
+  /classroom/join-with-code/{code}:
+    post:
+      consumes:
+      - application/json
+      description: Join a class using a unique code
+      parameters:
+      - description: Class Code
+        in: path
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Join a class with code
+      tags:
+      - classrooms
   /classroom/member:
     delete:
       consumes:

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -147,6 +147,8 @@ definitions:
         type: object
       duration_ms:
         type: integer
+      feed_back:
+        type: string
       is_verified:
         type: boolean
       item_snapshot:
@@ -486,6 +488,18 @@ definitions:
       topic:
         type: string
     type: object
+  types.UpdateGradeRequest:
+    properties:
+      feed_back:
+        type: string
+      is_verified:
+        type: boolean
+      score:
+        type: number
+    required:
+    - is_verified
+    - score
+    type: object
   types.UpdateSubmissionRequest:
     properties:
       assignment_id:
@@ -497,6 +511,8 @@ definitions:
         type: object
       duration_ms:
         type: integer
+      feed_back:
+        type: string
       is_verified:
         type: boolean
       item_snapshot:
@@ -2940,6 +2956,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Update an existing submission
+      tags:
+      - Submission
+  /submission/{submission_id}/grade:
+    put:
+      consumes:
+      - application/json
+      description: Update the grade for a specific submission by submission ID
+      parameters:
+      - description: Submission ID
+        in: path
+        name: submission_id
+        required: true
+        type: integer
+      - description: Updated Grade Data
+        in: body
+        name: grade
+        required: true
+        schema:
+          $ref: '#/definitions/types.UpdateGradeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update grade for a submission
       tags:
       - Submission
   /submission/assignment/{assignment_id}:

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -476,6 +476,8 @@ definitions:
     type: object
   types.UpdateClassRequest:
     properties:
+      banner_id:
+        type: integer
       description:
         type: string
       google_course_id:

--- a/cmd/api/docs/swagger.yaml
+++ b/cmd/api/docs/swagger.yaml
@@ -23,6 +23,13 @@ definitions:
       title:
         type: string
     type: object
+  types.BookMarkRequest:
+    properties:
+      class_id:
+        type: integer
+    required:
+    - class_id
+    type: object
   types.ChangePasswordRequest:
     properties:
       new_password:
@@ -358,8 +365,6 @@ definitions:
         type: integer
       class_id:
         type: integer
-      class_topic:
-        type: string
       description:
         type: string
       due_date:
@@ -612,6 +617,110 @@ paths:
       summary: Register new user
       tags:
       - auth
+  /bookmark:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a bookmark for a class
+      parameters:
+      - description: Bookmark data
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/types.BookMarkRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete a bookmark
+      tags:
+      - bookmark
+    get:
+      consumes:
+      - application/json
+      description: Get all bookmarks for a user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get bookmarks by user ID
+      tags:
+      - bookmark
+    post:
+      consumes:
+      - application/json
+      description: Create a bookmark for a class
+      parameters:
+      - description: Bookmark data
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/types.BookMarkRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create a bookmark
+      tags:
+      - bookmark
   /classroom:
     get:
       consumes:

--- a/internal/model/classroom.go
+++ b/internal/model/classroom.go
@@ -8,7 +8,6 @@ type Classroom struct {
 	Topic            string `gorm:"not null"`
 	Description      string `gorm:"null"`
 	Code             string `gorm:"null"`               // code for invitation in classroom
-	Favorite         int    `gorm:"not null;default:0"` // amount of stars
 	BannerID         int    `gorm:"null"`
 	Status           int    `gorm:"not null;default:0"` // 0: public, 1: private, 2: archived
 	GoogleCourseID   string `gorm:"null;"`

--- a/internal/model/playground.go
+++ b/internal/model/playground.go
@@ -10,7 +10,7 @@ type Playground struct {
 	AssignmentID int            `gorm:"not null"`
 	UserID       int            `gorm:"not null"`
 	Item         datatypes.JSON `gorm:"type:jsonb; not null"`
-	Status       string         `gorm:"not null;default:'in_progress'"` // e.g., "in_progress", "completed", "failed"
+	Status       string         `gorm:"not null;default:'in_progress'"` // e.g., "pending", "completed", "failed"
 	Assignment   Assignment     `gorm:"foreignKey:AssignmentID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -103,6 +103,10 @@ func (s *Server) Router() (http.Handler, func()) {
 	notificationUsecase := usecases.NewNotificationUsecase(notificationRepository)
 	notificationController := controller.NewNotificationController(notificationUsecase)
 
+	bookmarkRepository := repository.NewBookmarkRepository(s.db)
+	bookmarkUseCase := usecases.NewBookmarkUseCase(bookmarkRepository)
+	bookmarkController := controller.NewBookmarkController(bookmarkUseCase)
+
 	api := r.Group("/api/v2")
 	{
 		oauthController.OAuthRegisterRoutes(api)
@@ -166,6 +170,10 @@ func (s *Server) Router() (http.Handler, func()) {
 		notificationGroup := api.Group("/notifications").Use(security.Middleware()).(*gin.RouterGroup)
 		{
 			notificationController.NotificationRoutes(notificationGroup)
+		}
+		bookmarkGroup := api.Group("/bookmark").Use(security.Middleware()).(*gin.RouterGroup)
+		{
+			bookmarkController.BookmarkRoutes(bookmarkGroup)
 		}
 	}
 	if config.ENV == "dev" || config.ENV == "uat" {

--- a/internal/services/controller/bookmark.controller.go
+++ b/internal/services/controller/bookmark.controller.go
@@ -1,0 +1,127 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+type BookmarkController struct {
+	bookmarkUseCase usecases.BookmarkUseCase
+}
+
+func NewBookmarkController(bookmarkUseCase usecases.BookmarkUseCase) *BookmarkController {
+	return &BookmarkController{
+		bookmarkUseCase: bookmarkUseCase,
+	}
+}
+
+// @Summary      Create a bookmark
+// @Description  Create a bookmark for a class
+// @Tags         bookmark
+// @Accept       json
+// @Produce      json
+// @Param body body types.BookMarkRequest true "Bookmark data"
+// @Success      201   {object}  map[string]string
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /bookmark [post]
+func (c *BookmarkController) CreateBookmark(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+	var request types.BookMarkRequest
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
+		return
+	}
+
+	fmt.Print("Received bookmark request: ", request)
+
+	if err := c.bookmarkUseCase.CreateBookmarkUsecase(ctx, userID, request.ClassID); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create bookmark"})
+		return
+	}
+	ctx.JSON(http.StatusCreated, gin.H{"message": "Bookmark created successfully"})
+}
+
+// @Summary      Delete a bookmark
+// @Description  Delete a bookmark for a class
+// @Tags         bookmark
+// @Accept       json
+// @Produce      json
+// @Param  body body types.BookMarkRequest true "Bookmark data"
+// @Success      200   {object}  map[string]string
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /bookmark [delete]
+func (c *BookmarkController) DeleteBookmark(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+	var request types.BookMarkRequest
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
+		return
+	}
+	if err := c.bookmarkUseCase.DeleteBookmarkUsecase(ctx, userID, request.ClassID); err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete bookmark"})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"message": "Bookmark deleted successfully"})
+}
+
+// @Summary      Get bookmarks by user ID
+// @Description  Get all bookmarks for a user
+// @Tags         bookmark
+// @Accept       json
+// @Produce      json
+// @Success      200   {object}  map[string]interface{}
+// @Failure      401   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /bookmark [get]
+func (c *BookmarkController) GetBookmarksByUserID(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	bookmarks, err := c.bookmarkUseCase.GetBookmarksByUserIDUsecase(ctx, userID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve bookmarks"})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"bookmarks": bookmarks})
+}
+
+func (c *BookmarkController) BookmarkRoutes(r gin.IRoutes) {
+	r.POST("/", c.CreateBookmark)
+	r.DELETE("/", c.DeleteBookmark)
+	r.GET("/", c.GetBookmarksByUserID)
+}

--- a/internal/services/controller/class.controller.go
+++ b/internal/services/controller/class.controller.go
@@ -355,6 +355,43 @@ func (c *ClassController) GetClassRecentManyIDs(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, classes)
 }
 
+// @Summary      Join a class with code
+// @Description  Join a class using a unique code
+// @Tags         classrooms
+// @Accept       json
+// @Produce      json
+// @Param        code   path      string  true  "Class Code"
+// @Success      200   {object}  map[string]string
+// @Failure      400   {object}  map[string]string
+// @Failure      401   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /classroom/join-with-code/{code} [post]
+func (c *ClassController) JoinWithCode(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID type"})
+		return
+	}
+	code := ctx.Param("code")
+	if code == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Class code is required"})
+		return
+	}
+
+	err := c.classUseCase.JoinWithCodeUseCases(ctx, userID, code)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"message": "Joined class successfully"})
+}
+
 func (c *ClassController) ClassRoutes(r gin.IRoutes) {
 	r.POST("/", c.ClassCreateClass)
 	r.PUT("/:class_id", c.ClassUpdateClass)
@@ -363,6 +400,7 @@ func (c *ClassController) ClassRoutes(r gin.IRoutes) {
 	r.GET("/:class_id/members", c.GetAllMembersByClassID)
 	r.PUT("/:class_id/member/permission", c.ChangePermissionMember)
 	r.DELETE("/member", c.RemoveMemberInClass)
+	r.POST("/join-with-code/:code", c.JoinWithCode)
 }
 
 func (c *ClassController) ClassNotLoginRoutes(rg *gin.RouterGroup) {

--- a/internal/services/controller/submission.controller.go
+++ b/internal/services/controller/submission.controller.go
@@ -222,10 +222,58 @@ func (c *SubmissionController) GetAllSubmissionByAssignmentIDandUserID(ctx *gin.
 	ctx.JSON(http.StatusOK, submissionResponse)
 }
 
+// @Summary Update grade for a submission
+// @Description Update the grade for a specific submission by submission ID
+// @Tags Submission
+// @Accept json
+// @Produce json
+// @Param submission_id path int true "Submission ID"
+// @Param grade body types.UpdateGradeRequest true "Updated Grade Data"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security     BearerAuth
+// @Router /submission/{submission_id}/grade [put]
+func (c *SubmissionController) UpdateGrade(ctx *gin.Context) {
+	userIDVal, exist := ctx.Get("user_id")
+	if !exist {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user ID"})
+		return
+	}
+
+	submissionIDStr := ctx.Param("submission_id")
+	submissionID, err := strconv.Atoi(submissionIDStr)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid submission ID"})
+		return
+	}
+
+	var req types.UpdateGradeRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	err = c.submissionUseCase.UpdateGradeUseCase(ctx.Request.Context(), userID, submissionID, req)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "grade updated successfully"})
+}
+
 func (c *SubmissionController) SubmissionRoutes(r gin.IRoutes) {
 	r.POST("/", c.CreateSubmission)
 	r.PUT("/:submission_id", c.UpdateSubmission)
 	r.GET("/assignment/:assignment_id", c.GetAllSubmissionByAssignmentID)
 	r.GET("/:submission_id", c.GetSubmissionByID)
 	r.GET("/assignment/:assignment_id/user", c.GetAllSubmissionByAssignmentIDandUserID)
+	r.PUT("/:submission_id/grade", c.UpdateGrade)
 }

--- a/internal/services/controller/user.controller.go
+++ b/internal/services/controller/user.controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"net/http"
 	"strconv"
 
 	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
@@ -32,14 +33,14 @@ func NewUserController(userUseCase usecases.UserUseCase) *UserController {
 func (u *UserController) CreateUserController(ctx *gin.Context) {
 	var request types.CreateUserRequest
 	if err := ctx.ShouldBindJSON(&request); err != nil {
-		ctx.JSON(400, gin.H{"error": "Invalid request data"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
 		return
 	}
 	if err := u.userUseCase.CreateUserUsecase(ctx, &request); err != nil {
-		ctx.JSON(500, gin.H{"error": "Failed to create user"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
 		return
 	}
-	ctx.JSON(201, gin.H{"message": "User created successfully"})
+	ctx.JSON(http.StatusCreated, gin.H{"message": "User created successfully"})
 }
 
 // @Summary      Update user
@@ -57,19 +58,19 @@ func (u *UserController) CreateUserController(ctx *gin.Context) {
 func (u *UserController) UpdateUserController(ctx *gin.Context) {
 	userID, err := strconv.Atoi(ctx.Param("id"))
 	if err != nil {
-		ctx.JSON(400, gin.H{"error": "Invalid user ID"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
 		return
 	}
 	var request types.UpdateUserRequest
 	if err := ctx.ShouldBindJSON(&request); err != nil {
-		ctx.JSON(400, gin.H{"error": "Invalid request data"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request data"})
 		return
 	}
 	if err := u.userUseCase.UpdateUsersUsecase(ctx, userID, &request); err != nil {
-		ctx.JSON(500, gin.H{"error": "Failed to update user"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update user"})
 		return
 	}
-	ctx.JSON(200, gin.H{"message": "User updated successfully"})
+	ctx.JSON(http.StatusOK, gin.H{"message": "User updated successfully"})
 }
 
 // @Summary      Delete user
@@ -86,14 +87,14 @@ func (u *UserController) UpdateUserController(ctx *gin.Context) {
 func (u *UserController) DeleteUserController(ctx *gin.Context) {
 	var userID, err = strconv.Atoi(ctx.Param("id"))
 	if err != nil {
-		ctx.JSON(400, gin.H{"error": "Invalid user ID"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
 		return
 	}
 	if err := u.userUseCase.DeleteUserUsecase(ctx, userID); err != nil {
-		ctx.JSON(500, gin.H{"error": "Failed to delete user"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete user"})
 		return
 	}
-	ctx.JSON(200, gin.H{"message": "User deleted successfully"})
+	ctx.JSON(http.StatusOK, gin.H{"message": "User deleted successfully"})
 }
 
 // @Summary      Get all users
@@ -108,10 +109,10 @@ func (u *UserController) DeleteUserController(ctx *gin.Context) {
 func (u *UserController) GetAllUsersController(ctx *gin.Context) {
 	users, err := u.userUseCase.GetAllUsersUsecase(ctx)
 	if err != nil {
-		ctx.JSON(500, gin.H{"error": "Failed to retrieve users"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve users"})
 		return
 	}
-	ctx.JSON(200, users)
+	ctx.JSON(http.StatusOK, users)
 }
 
 // @Summary      Get my classes
@@ -126,20 +127,20 @@ func (u *UserController) GetAllUsersController(ctx *gin.Context) {
 func (u *UserController) GetMeClassesController(ctx *gin.Context) {
 	userIDVal, exists := ctx.Get("user_id")
 	if !exists {
-		ctx.JSON(401, gin.H{"error": "Unauthorized"})
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return
 	}
 	userID, ok := userIDVal.(int)
 	if !ok {
-		ctx.JSON(400, gin.H{"error": "Invalid user ID type"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID type"})
 		return
 	}
 	classes, err := u.userUseCase.GetMeClassUsecase(ctx, userID)
 	if err != nil {
-		ctx.JSON(500, gin.H{"error": "Failed to retrieve classes"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve classes"})
 		return
 	}
-	ctx.JSON(200, classes)
+	ctx.JSON(http.StatusOK, classes)
 }
 
 // @Summary      Get owner classes
@@ -154,20 +155,48 @@ func (u *UserController) GetMeClassesController(ctx *gin.Context) {
 func (u *UserController) GetOwnerClassesController(ctx *gin.Context) {
 	userIDVal, exists := ctx.Get("user_id")
 	if !exists {
-		ctx.JSON(401, gin.H{"error": "Unauthorized"})
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return
 	}
 	userID, ok := userIDVal.(int)
 	if !ok {
-		ctx.JSON(400, gin.H{"error": "Invalid user ID type"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID type"})
 		return
 	}
 	classes, err := u.userUseCase.GetOwnerClassUsecase(ctx, userID)
 	if err != nil {
-		ctx.JSON(500, gin.H{"error": "Failed to retrieve classes"})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve classes"})
 		return
 	}
-	ctx.JSON(200, classes)
+	ctx.JSON(http.StatusOK, classes)
+}
+
+// @Summary      Get my tasks
+// @Description  Retrieve tasks of the authenticated user
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Success      200   {array}   types.TaskMeResponse
+// @Failure      500   {object}  map[string]string
+// @Security     BearerAuth
+// @Router       /user/me/task [get]
+func (u *UserController) GetMeTaskController(ctx *gin.Context) {
+	userIDVal, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID type"})
+		return
+	}
+	tasks, err := u.userUseCase.GetMeTaskUsecase(ctx, userID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve tasks"})
+		return
+	}
+	ctx.JSON(http.StatusOK, tasks)
 }
 
 func (u *UserController) UserRoutes(r gin.IRoutes) {
@@ -177,4 +206,5 @@ func (u *UserController) UserRoutes(r gin.IRoutes) {
 	r.POST("/", u.CreateUserController)
 	r.GET("/me/classroom", u.GetMeClassesController)
 	r.GET("/owner/classroom", u.GetOwnerClassesController)
+	r.GET("/me/task", u.GetMeTaskController)
 }

--- a/internal/services/repository/assignment.repository.go
+++ b/internal/services/repository/assignment.repository.go
@@ -220,6 +220,9 @@ func (r *assignmentRepository) EditAssignmentByAssignmentID(ctx context.Context,
 	if assignment.Grade != 0 {
 		existingAssignment.Grade = assignment.Grade
 	}
+	if !assignment.DueDate.IsZero() {
+		existingAssignment.DueDate = assignment.DueDate
+	}
 
 	settingBytes, _ := json.Marshal(assignment.Setting)
 	conditionBytes, _ := json.Marshal(assignment.Condition)

--- a/internal/services/repository/assignment.repository.go
+++ b/internal/services/repository/assignment.repository.go
@@ -41,8 +41,6 @@ func (r *assignmentRepository) GetAssignmentsByClassID(ctx context.Context, clas
 		return nil, gorm.ErrRecordNotFound
 	}
 
-	dueDate := time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339) // Example due date set to one week from now := 2023-10-01T15:04:05Z07:00
-
 	var assignments []model.Assignment
 	if err := r.db.WithContext(ctx).Where("class_id = ?", classID).Find(&assignments).Error; err != nil {
 		return nil, err
@@ -68,6 +66,8 @@ func (r *assignmentRepository) GetAssignmentsByClassID(ctx context.Context, clas
 		} else {
 			condition = map[string]interface{}{}
 		}
+
+		dueDate := assignment.DueDate.Format(time.RFC3339)
 
 		assignmentResponses = append(assignmentResponses, types.AssignmentResponse{
 			ID:          int(assignment.ID),
@@ -219,9 +219,6 @@ func (r *assignmentRepository) EditAssignmentByAssignmentID(ctx context.Context,
 	}
 	if assignment.Grade != 0 {
 		existingAssignment.Grade = assignment.Grade
-	}
-	if !assignment.DueDate.IsZero() {
-		existingAssignment.DueDate = assignment.DueDate
 	}
 
 	settingBytes, _ := json.Marshal(assignment.Setting)

--- a/internal/services/repository/assignment.repository.go
+++ b/internal/services/repository/assignment.repository.go
@@ -220,6 +220,10 @@ func (r *assignmentRepository) EditAssignmentByAssignmentID(ctx context.Context,
 	if assignment.Grade != 0 {
 		existingAssignment.Grade = assignment.Grade
 	}
+	// Update DueDate if provided (check for non-zero time)
+	if !assignment.DueDate.IsZero() {
+		existingAssignment.DueDate = assignment.DueDate
+	}
 
 	settingBytes, _ := json.Marshal(assignment.Setting)
 	conditionBytes, _ := json.Marshal(assignment.Condition)

--- a/internal/services/repository/bookmark.repository.go
+++ b/internal/services/repository/bookmark.repository.go
@@ -1,0 +1,90 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/model"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+	"gorm.io/gorm"
+)
+
+type BookmarkRepository interface {
+	CreateBookmark(ctx context.Context, userID, classID int) error
+	DeleteBookmark(ctx context.Context, userID, classID int) error
+	GetBookmarksByUserID(ctx context.Context, userID int) (*[]types.ClassResponse, error)
+}
+
+type bookmarkRepository struct {
+	db *gorm.DB
+}
+
+func NewBookmarkRepository(db *gorm.DB) BookmarkRepository {
+	return &bookmarkRepository{db: db}
+}
+
+func (r *bookmarkRepository) CreateBookmark(ctx context.Context, userID, classID int) error {
+	bookmark := model.BookMark{
+		UserID:  userID,
+		ClassID: classID,
+	}
+
+	if err := r.db.WithContext(ctx).Create(&bookmark).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *bookmarkRepository) DeleteBookmark(ctx context.Context, userID, classID int) error {
+	if err := r.db.WithContext(ctx).Where("user_id = ? AND class_id = ?", userID, classID).Delete(&model.BookMark{}).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *bookmarkRepository) GetBookmarksByUserID(ctx context.Context, userID int) (*[]types.ClassResponse, error) {
+	var bookmarks []model.BookMark
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Find(&bookmarks).Error; err != nil {
+		return nil, err
+	}
+
+	var classIDs []int
+	for _, bookmark := range bookmarks {
+		classIDs = append(classIDs, bookmark.ClassID)
+	}
+
+	var classes []model.Classroom
+	if err := r.db.WithContext(ctx).Where("id IN ?", classIDs).Find(&classes).Error; err != nil {
+		return nil, err
+	}
+
+	classResponses := make([]types.ClassResponse, 0, len(classes))
+
+	for _, class := range classes {
+		var owner model.User
+		if err := r.db.WithContext(ctx).Where("id = ?", class.OwnerId).First(&owner).Error; err != nil {
+			return nil, err
+		}
+
+		var memberCount int64
+		if err := r.db.WithContext(ctx).Model(&model.Member{}).Where("class_id = ?", class.ID).Count(&memberCount).Error; err != nil {
+			return nil, err
+		}
+		classResponses = append(classResponses, types.ClassResponse{
+			ID:               int(class.ID),
+			Topic:            class.Topic,
+			Description:      class.Description,
+			Code:             class.Code,
+			GoogleCourseID:   class.GoogleCourseID,
+			GoogleCourseLink: class.GoogleCourseLink,
+			GoogleSyncedAt:   class.GoogleSyncedAt,
+			OwnerID:          int(class.OwnerId),
+			OwnerName:        owner.Name,
+			MemberAmount:     memberCount,
+			Status:           class.Status,
+			Favorite:         class.Favorite,
+			BannerID:         class.BannerID,
+		})
+	}
+
+	return &classResponses, nil
+}

--- a/internal/services/repository/bookmark.repository.go
+++ b/internal/services/repository/bookmark.repository.go
@@ -81,7 +81,6 @@ func (r *bookmarkRepository) GetBookmarksByUserID(ctx context.Context, userID in
 			OwnerName:        owner.Name,
 			MemberAmount:     memberCount,
 			Status:           class.Status,
-			Favorite:         class.Favorite,
 			BannerID:         class.BannerID,
 		})
 	}

--- a/internal/services/repository/class.repository.go
+++ b/internal/services/repository/class.repository.go
@@ -24,6 +24,7 @@ type ClassRepository interface {
 	ChangePermissionMember(ctx context.Context, userID, classID int, newRole string) error
 	RemoveMemberInClass(ctx context.Context, classID, userID int) error
 	GetClassRecentManyIDs(ctx context.Context, limit []int) (*[]types.ClassResponse, error)
+	JoinWithCode(ctx context.Context, userID int, code string) error
 }
 
 type classRepository struct {
@@ -384,4 +385,37 @@ func (r *classRepository) GetClassRecentManyIDs(ctx context.Context, limit []int
 	}
 
 	return &classResponses, nil
+}
+
+func (r *classRepository) JoinWithCode(ctx context.Context, userID int, code string) error {
+	var class model.Classroom
+	if err := r.db.WithContext(ctx).Where("code = ?", code).First(&class).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return gorm.ErrRecordNotFound
+		}
+		return err
+	}
+
+	// Check if the user is the owner of the class
+	if err := r.db.WithContext(ctx).Where("id = ? AND owner_id = ?", class.ID, userID).First(&class).Error; err == nil {
+		return errors.New("owner cannot join their own class as member")
+	}
+
+	// Check if the user is already a member of the class
+	var member model.Member
+	if err := r.db.WithContext(ctx).Where("user_id = ? AND class_id = ?", userID, class.ID).First(&member).Error; err == nil {
+		return errors.New("user already joined the class")
+	}
+
+	var newMember model.Member
+	newMember.UserID = userID
+	newMember.ClassID = int(class.ID)
+	newMember.JoinAt = time.Now()
+	newMember.Role = "member"
+
+	if err := r.db.WithContext(ctx).Create(&newMember).Error; err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/services/repository/class.repository.go
+++ b/internal/services/repository/class.repository.go
@@ -81,7 +81,6 @@ func (r *classRepository) GetAllClasses(ctx context.Context) (*[]types.ClassResp
 			OwnerName:        owner.Name,
 			Status:           class.Status,
 			MemberAmount:     memberCount,
-			Favorite:         class.Favorite,
 			BannerID:         class.BannerID,
 		})
 	}
@@ -201,7 +200,6 @@ func (r *classRepository) GetClassByID(ctx context.Context, classID int) (*types
 		OwnerName:        owner.Name,
 		MemberAmount:     memberCount,
 		Status:           class.Status,
-		Favorite:         class.Favorite,
 		BannerID:         class.BannerID,
 	}
 
@@ -308,7 +306,6 @@ func (r *classRepository) GetAllClassPublic(ctx context.Context) (*[]types.Class
 			OwnerName:        owner.Name,
 			MemberAmount:     memberCount,
 			Status:           class.Status,
-			Favorite:         class.Favorite,
 			BannerID:         class.BannerID,
 		})
 	}
@@ -382,7 +379,6 @@ func (r *classRepository) GetClassRecentManyIDs(ctx context.Context, limit []int
 			OwnerName:        owner.Name,
 			MemberAmount:     memberCount,
 			Status:           class.Status,
-			Favorite:         class.Favorite,
 			BannerID:         class.BannerID,
 		})
 	}

--- a/internal/services/repository/invitation.repository.go
+++ b/internal/services/repository/invitation.repository.go
@@ -138,12 +138,18 @@ func (r *invitationRepository) UpdateInvitationStatus(ctx context.Context, invit
 		return err
 	}
 
-	if status == "accepted" {
+	switch status {
+	case "accepted":
 		newMember := model.Member{
 			UserID:  userID,
 			ClassID: invitation.ClassID,
+			Role:    "member",
 		}
 		if err := r.db.WithContext(ctx).Create(&newMember).Error; err != nil {
+			return err
+		}
+	case "declined":
+		if err := r.db.WithContext(ctx).Delete(&invitation).Error; err != nil {
 			return err
 		}
 	}

--- a/internal/services/repository/submission.repository.go
+++ b/internal/services/repository/submission.repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/TroJanBoi/assembly-visual-backend/internal/model"
 	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
@@ -16,6 +17,7 @@ type SubmissionRepository interface {
 	GetAllSubmissionByAssignmentID(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error)
 	GetSubmissionByID(ctx context.Context, userID, submissionID int) (*types.SubmissionResponse, error)
 	GetAllSubmissionByAssignmentIDandUserID(ctx context.Context, assignmentID, userID int) (*[]types.SubmissionResponse, error)
+	UpdateGrade(ctx context.Context, userID, submissionID int, request types.UpdateGradeRequest) error
 }
 
 type submissionRepository struct {
@@ -49,6 +51,10 @@ func (r *submissionRepository) CreateSubmission(ctx context.Context, userId int,
 	clientResult, _ := json.Marshal(request.ClientResult)
 	serverResult, _ := json.Marshal(request.ServerResult)
 
+	if request.Score > float64(assignment.Grade) {
+		request.Score = float64(assignment.Grade)
+	}
+
 	newSubmission := model.Submission{
 		AssignmentID:  int(request.AssignmentID),
 		UserID:        int(userId),
@@ -75,6 +81,12 @@ func (r *submissionRepository) UpdateSubmission(ctx context.Context, userID, sub
 		return err
 	}
 
+	var assignment model.Assignment
+	err = r.db.WithContext(ctx).Where("id = ?", submission.AssignmentID).First(&assignment).Error
+	if err != nil {
+		return err
+	}
+
 	// อนุญาตให้แก้ไขได้ทุกฟิลด์ เจ้าของ submission และ owner ของ assignment และ member ที่เป็น TA เท่านั้น
 	// Select * FROM classroom c JOIN assignment a ON a.class_id = c.id JOIN member m ON m.class_id = c.id WHERE a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?))
 	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Joins("JOIN member m ON m.class_id = c.id").Joins("JOIN submission s ON s.assignment_id = a.id").Where("a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?) OR s.user_id = ?)", submission.AssignmentID, userID, userID, "ta", userID).First(&model.Classroom{}).Error
@@ -86,14 +98,20 @@ func (r *submissionRepository) UpdateSubmission(ctx context.Context, userID, sub
 	clientResult, _ := json.Marshal(request.ClientResult)
 	serverResult, _ := json.Marshal(request.ServerResult)
 
+	if request.Score > float64(assignment.Grade) {
+		request.Score = float64(assignment.Grade)
+	} else {
+		submission.Score = request.Score
+	}
+
 	submission.AttemptNumber = int(request.AttemptNumber)
 	submission.ItemSnapshot = datatypes.JSON(snapshot)
 	submission.ClientResult = datatypes.JSON(clientResult)
 	submission.ServerResult = datatypes.JSON(serverResult)
-	submission.Score = request.Score
-	submission.Status = request.Status
 	submission.IsVerified = request.IsVerified
 	submission.DurationMS = request.DurationMS
+	submission.FeedBack = request.FeedBack
+	submission.UpdatedAt = time.Now()
 
 	if err := r.db.WithContext(ctx).Save(&submission).Error; err != nil {
 		return err
@@ -285,4 +303,44 @@ func (r *submissionRepository) GetAllSubmissionByAssignmentIDandUserID(ctx conte
 		})
 	}
 	return &submissionResponse, nil
+}
+
+func (r *submissionRepository) UpdateGrade(ctx context.Context, userID, submissionID int, request types.UpdateGradeRequest) error {
+	var submission model.Submission
+	err := r.db.WithContext(ctx).Where("id = ?", submissionID).First(&submission).Error
+	if err != nil {
+		return err
+	}
+
+	var assignment model.Assignment
+	err = r.db.WithContext(ctx).Where("id = ?", submission.AssignmentID).First(&assignment).Error
+	if err != nil {
+		return err
+	}
+
+	// อนุญาตให้แก้ไขได้ทุกฟิลด์ เจ้าของ submission และ owner ของ assignment และ member ที่เป็น TA เท่านั้น
+	err = r.db.WithContext(ctx).Table("classroom c").Select("c.id, c.owner_id").Joins("JOIN assignment a ON a.class_id = c.id").Joins("JOIN member m ON m.class_id = c.id").Joins("JOIN submission s ON s.assignment_id = a.id").Where("a.id = ? AND (c.owner_id = ? OR (m.user_id = ? AND m.role = ?) OR s.user_id = ?)", submission.AssignmentID, userID, userID, "ta", userID).First(&model.Classroom{}).Error
+	if err != nil {
+		return err
+	}
+
+	// ถ้า score ที่ส่งมามากกว่า grade ของ assignment ให้ตั้งเป็น grade ของ assignment แทน และ ถ้าไม่ก็ให้ตั้งเป็น score ที่ส่งมา
+	if request.Score > float64(assignment.Grade) {
+		submission.Score = float64(assignment.Grade)
+	} else {
+		submission.Score = request.Score
+	}
+	submission.FeedBack = request.FeedBack
+	submission.IsVerified = request.IsVerified
+	submission.UpdatedAt = time.Now()
+
+	submission.Status = "submitted"
+	if err := r.db.WithContext(ctx).Save(&submission).Error; err != nil {
+		submission.Status = "failed"
+		if err := r.db.WithContext(ctx).Save(&submission).Error; err != nil {
+			return err
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/services/repository/submission.repository.go
+++ b/internal/services/repository/submission.repository.go
@@ -70,7 +70,7 @@ func (r *submissionRepository) CreateSubmission(ctx context.Context, userId int,
 
 func (r *submissionRepository) UpdateSubmission(ctx context.Context, userID, submissionID int, request types.UpdateSubmissionRequest) error {
 	var submission model.Submission
-	err := r.db.WithContext(ctx).Where("id = ?", submissionID, userID).First(&submission).Error
+	err := r.db.WithContext(ctx).Where("id = ?", submissionID).First(&submission).Error
 	if err != nil {
 		return err
 	}

--- a/internal/services/repository/user.repository.go
+++ b/internal/services/repository/user.repository.go
@@ -240,26 +240,26 @@ func (r *userRepository) GetMeTask(ctx context.Context, userID int) (*[]types.Ta
 		return nil, fmt.Errorf("failed to retrieve assignments: %w", err)
 	}
 
-	assignmentIDList := make([]int, len(assignments))
-	for i, assignment := range assignments {
-		assignmentIDList[i] = int(assignment.ID)
+	var submissions []model.Submission
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Find(&submissions).Error; err != nil {
+		return nil, fmt.Errorf("failed to retrieve submissions: %w", err)
 	}
 
-	var playgrounds []model.Playground
-	if err := r.db.WithContext(ctx).Where("assignment_id IN ? AND user_id = ? AND status = ?", assignmentIDList, userID, "in_progress").Find(&playgrounds).Error; err != nil {
-		return nil, fmt.Errorf("failed to retrieve playground records: %w", err)
-	}
-
-	var playgorundLst []int
-	for _, pg := range playgrounds {
-		playgorundLst = append(playgorundLst, int(pg.AssignmentID))
-	}
-
+	var status string
 	var taskResp []types.TaskMeResponse
-	for _, pg := range playgorundLst {
-		var assignment model.Assignment
-		if err := r.db.WithContext(ctx).Where("id = ?", pg).First(&assignment).Error; err != nil {
-			return nil, fmt.Errorf("failed to retrieve assignment: %w", err)
+	for _, assignment := range assignments {
+
+		var countSubmissionByAssignmentID int64
+		if err := r.db.WithContext(ctx).Model(&model.Submission{}).Where("user_id = ? AND assignment_id = ?", userID, assignment.ID).Count(&countSubmissionByAssignmentID).Error; err != nil {
+			return nil, fmt.Errorf("failed to count submissions: %w", err)
+		}
+
+		if time.Now().After(assignment.DueDate) {
+			status = "overdue"
+		} else if countSubmissionByAssignmentID > 0 {
+			status = "completed"
+		} else {
+			status = "in_progress"
 		}
 
 		taskResp = append(taskResp, types.TaskMeResponse{
@@ -269,9 +269,31 @@ func (r *userRepository) GetMeTask(ctx context.Context, userID int) (*[]types.Ta
 			AssignmentTitle: assignment.Title,
 			Description:     assignment.Description,
 			MaxAttempt:      assignment.MaxAttempt,
-			PlaygroundID:    pg,
 			DueDate:         assignment.DueDate.Format((time.RFC3339)),
+			Status:          status,
 		})
 	}
 	return &taskResp, nil
+
+	// var status string
+	// var taskResp []types.TaskMeResponse
+	// for _, assignment := range assignments {
+	// 	if time.Now().After(assignment.DueDate) {
+	// 		status = "overdue"
+	// 	} else if
+	// 	} else {
+	// 		status = "in_progress"
+	// 	}
+	// 	taskResp = append(taskResp, types.TaskMeResponse{
+	// 		ClassID:         int(assignment.ClassID),
+	// 		Favorite:        int(assignment.Classroom.Favorite),
+	// 		AssignmentID:    int(assignment.ID),
+	// 		AssignmentTitle: assignment.Title,
+	// 		Description:     assignment.Description,
+	// 		MaxAttempt:      assignment.MaxAttempt,
+	// 		DueDate:         assignment.DueDate.Format((time.RFC3339)),
+	// 		Status:          status,
+	// 	})
+	// }
+	// return &taskResp, nil
 }

--- a/internal/services/repository/user.repository.go
+++ b/internal/services/repository/user.repository.go
@@ -165,7 +165,6 @@ func (r *userRepository) GetMeClass(ctx context.Context, userID int) (*[]types.C
 			GoogleCourseID:   class.GoogleCourseID,
 			GoogleCourseLink: class.GoogleCourseLink,
 			GoogleSyncedAt:   class.GoogleSyncedAt,
-			Favorite:         int(class.Favorite),
 			BannerID:         int(class.BannerID),
 			MemberAmount:     countMember,
 		})
@@ -204,7 +203,6 @@ func (r *userRepository) GetOwnerClass(ctx context.Context, userID int) (*[]type
 			GoogleCourseID:   class.GoogleCourseID,
 			GoogleCourseLink: class.GoogleCourseLink,
 			GoogleSyncedAt:   class.GoogleSyncedAt,
-			Favorite:         int(class.Favorite),
 			BannerID:         int(class.BannerID),
 			MemberAmount:     countMember,
 		})
@@ -264,7 +262,6 @@ func (r *userRepository) GetMeTask(ctx context.Context, userID int) (*[]types.Ta
 
 		taskResp = append(taskResp, types.TaskMeResponse{
 			ClassID:         int(assignment.ClassID),
-			Favorite:        int(assignment.Classroom.Favorite),
 			AssignmentID:    int(assignment.ID),
 			AssignmentTitle: assignment.Title,
 			Description:     assignment.Description,
@@ -274,26 +271,4 @@ func (r *userRepository) GetMeTask(ctx context.Context, userID int) (*[]types.Ta
 		})
 	}
 	return &taskResp, nil
-
-	// var status string
-	// var taskResp []types.TaskMeResponse
-	// for _, assignment := range assignments {
-	// 	if time.Now().After(assignment.DueDate) {
-	// 		status = "overdue"
-	// 	} else if
-	// 	} else {
-	// 		status = "in_progress"
-	// 	}
-	// 	taskResp = append(taskResp, types.TaskMeResponse{
-	// 		ClassID:         int(assignment.ClassID),
-	// 		Favorite:        int(assignment.Classroom.Favorite),
-	// 		AssignmentID:    int(assignment.ID),
-	// 		AssignmentTitle: assignment.Title,
-	// 		Description:     assignment.Description,
-	// 		MaxAttempt:      assignment.MaxAttempt,
-	// 		DueDate:         assignment.DueDate.Format((time.RFC3339)),
-	// 		Status:          status,
-	// 	})
-	// }
-	// return &taskResp, nil
 }

--- a/internal/services/repository/user.repository.go
+++ b/internal/services/repository/user.repository.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/TroJanBoi/assembly-visual-backend/internal/model"
 	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
@@ -20,6 +21,7 @@ type UserRepository interface {
 	DeleteUser(ctx context.Context, userID int) error
 	GetMeClass(ctx context.Context, userID int) (*[]types.ClassMeResponse, error)
 	GetOwnerClass(ctx context.Context, userID int) (*[]types.ClassMeResponse, error)
+	GetMeTask(ctx context.Context, userID int) (*[]types.TaskMeResponse, error)
 }
 
 type userRepository struct {
@@ -208,4 +210,68 @@ func (r *userRepository) GetOwnerClass(ctx context.Context, userID int) (*[]type
 		})
 	}
 	return &classResp, nil
+}
+
+func (r *userRepository) GetMeTask(ctx context.Context, userID int) (*[]types.TaskMeResponse, error) {
+	var member []model.Member // check member
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Find(&member).Error; err != nil {
+		return nil, fmt.Errorf("failed to retrieve member records: %w", err)
+	}
+
+	var classIDs []int
+	for _, m := range member {
+		classIDs = append(classIDs, int(m.ClassID))
+	}
+
+	var classes []model.Classroom // select classes where user is member
+	if err := r.db.WithContext(ctx).Where("id IN ?", classIDs).Find(&classes).Error; err != nil {
+		return nil, fmt.Errorf("failed to retrieve classes: %w", err)
+	}
+
+	// get class id list for select tasks
+	var classIDList []int
+	for _, class := range classes {
+		classIDList = append(classIDList, int(class.ID))
+	}
+
+	// select tasks where class id in classIDList
+	var assignments []model.Assignment
+	if err := r.db.WithContext(ctx).Where("class_id IN ?", classIDList).Find(&assignments).Error; err != nil {
+		return nil, fmt.Errorf("failed to retrieve assignments: %w", err)
+	}
+
+	assignmentIDList := make([]int, len(assignments))
+	for i, assignment := range assignments {
+		assignmentIDList[i] = int(assignment.ID)
+	}
+
+	var playgrounds []model.Playground
+	if err := r.db.WithContext(ctx).Where("assignment_id IN ? AND user_id = ? AND status = ?", assignmentIDList, userID, "in_progress").Find(&playgrounds).Error; err != nil {
+		return nil, fmt.Errorf("failed to retrieve playground records: %w", err)
+	}
+
+	var playgorundLst []int
+	for _, pg := range playgrounds {
+		playgorundLst = append(playgorundLst, int(pg.AssignmentID))
+	}
+
+	var taskResp []types.TaskMeResponse
+	for _, pg := range playgorundLst {
+		var assignment model.Assignment
+		if err := r.db.WithContext(ctx).Where("id = ?", pg).First(&assignment).Error; err != nil {
+			return nil, fmt.Errorf("failed to retrieve assignment: %w", err)
+		}
+
+		taskResp = append(taskResp, types.TaskMeResponse{
+			ClassID:         int(assignment.ClassID),
+			Favorite:        int(assignment.Classroom.Favorite),
+			AssignmentID:    int(assignment.ID),
+			AssignmentTitle: assignment.Title,
+			Description:     assignment.Description,
+			MaxAttempt:      assignment.MaxAttempt,
+			PlaygroundID:    pg,
+			DueDate:         assignment.DueDate.Format((time.RFC3339)),
+		})
+	}
+	return &taskResp, nil
 }

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -179,14 +179,13 @@ type FEBehavior struct {
 // }
 
 type EditAssignmentRequest struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	MaxAttempt  int    `json:"max_attempt"`
-	Grade       int    `json:"grade"` // total grade of the assignment
-	// Setting     AssignmentSettings  `json:"settings"`
-	// Condition   AssignmentCondition `json:"condition"`
-	Setting   map[string]interface{} `json:"setting"`
-	Condition map[string]interface{} `json:"condition"`
+	Title       string                 `json:"title"`
+	Description string                 `json:"description"`
+	MaxAttempt  int                    `json:"max_attempt"`
+	Grade       int                    `json:"grade"` // total grade of the assignment
+	Setting     map[string]interface{} `json:"setting"`
+	Condition   map[string]interface{} `json:"condition"`
+	DueDate     time.Time              `json:"due_date"`
 }
 
 type MemberResponse struct {

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -386,6 +386,7 @@ type CreateSubmissionRequest struct {
 	Status        string                 `json:"status"`
 	IsVerified    bool                   `json:"is_verified"`
 	DurationMS    int                    `json:"duration_ms"`
+	FeedBack      string                 `json:"feed_back"`
 }
 
 type UpdateSubmissionRequest struct {
@@ -398,6 +399,7 @@ type UpdateSubmissionRequest struct {
 	Score         float64                `json:"score"`
 	Status        string                 `json:"status"`
 	IsVerified    bool                   `json:"is_verified"`
+	FeedBack      string                 `json:"feed_back"`
 	DurationMS    int                    `json:"duration_ms"`
 }
 
@@ -471,4 +473,14 @@ type TaskMeDetailResponse struct {
 
 type BookMarkRequest struct {
 	ClassID int `json:"class_id" binding:"required"`
+}
+
+type UpdateGradeRequest struct {
+	Score      float64 `json:"score" binding:"required"`
+	IsVerified bool    `json:"is_verified" binding:"required"`
+	FeedBack   string  `json:"feed_back"`
+}
+
+type BadRequestError struct {
+	Message string `json:"message"`
 }

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -452,3 +452,23 @@ type TaskMeResponse struct {
 	DueDate string `json:"due_date"`
 	Status  string `json:"status"` // e.g., "not_started", "in_progress", "completed", "overdue"
 }
+
+type TaskMeDetailResponse struct {
+	ClassID         int                  `json:"class_id"`
+	BannerID        int                  `json:"banner_id"`
+	Favorite        int                  `json:"favorite"`
+	AssignmentID    int                  `json:"assignment_id"`
+	AssignmentTitle string               `json:"assignment_title"`
+	Description     string               `json:"description"`
+	MaxAttempt      int                  `json:"max_attempt"`
+	DueDate         string               `json:"due_date"`
+	Status          string               `json:"status"` // e.g., "not_started", "in_progress", "completed", "overdue"
+	Submissions     []SubmissionResponse `json:"submissions"`
+	Playground      *PlaygroundResponse  `json:"playground,omitempty"`
+	Assignment      *AssignmentResponse  `json:"assignment,omitempty"`
+	Class           *ClassMeResponse     `json:"class,omitempty"`
+}
+
+type BookMarkRequest struct {
+	ClassID int `json:"class_id" binding:"required"`
+}

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -146,7 +146,6 @@ type AssignmentCondition struct {
 type CreateAssignmentRequest struct {
 	Title       string                 `json:"title" binding:"required"`
 	Description string                 `json:"description"`
-	DueDate     time.Time              `json:"due_date"`
 	MaxAttempt  int                    `json:"max_attempt"`
 	Settings    map[string]interface{} `json:"settings"`
 	Condition   map[string]interface{} `json:"condition"`
@@ -439,4 +438,19 @@ type NotificationResponse struct {
 
 type RecentRequest struct {
 	Limit []int `json:"limit" binding:"required"`
+}
+
+type TaskMeResponse struct {
+	ClassID         int    `json:"class_id"`
+	ClassTopic      string `json:"class_topic"`
+	BannerID        int    `json:"banner_id"`
+	Favorite        int    `json:"favorite"`
+	AssignmentID    int    `json:"assignment_id"`
+	AssignmentTitle string `json:"assignment_title"`
+	Description     string `json:"description"`
+	MaxAttempt      int    `json:"max_attempt"`
+	PlaygroundID    int    `json:"playground_id"`
+
+	DueDate string `json:"due_date"`
+	Status  string `json:"status"` // e.g., "not_started", "in_progress", "completed", "overdue"
 }

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -102,6 +102,7 @@ type UpdateClassRequest struct {
 	GoogleCourseID   string `json:"google_course_id"`
 	GoogleCourseLink string `json:"google_course_link"`
 	Status           int    `json:"status"` // public or private
+	BannerID         int    `json:"banner_id"`
 }
 
 type AssignmentResponse struct {

--- a/internal/services/types/types.go
+++ b/internal/services/types/types.go
@@ -442,14 +442,12 @@ type RecentRequest struct {
 
 type TaskMeResponse struct {
 	ClassID         int    `json:"class_id"`
-	ClassTopic      string `json:"class_topic"`
 	BannerID        int    `json:"banner_id"`
 	Favorite        int    `json:"favorite"`
 	AssignmentID    int    `json:"assignment_id"`
 	AssignmentTitle string `json:"assignment_title"`
 	Description     string `json:"description"`
 	MaxAttempt      int    `json:"max_attempt"`
-	PlaygroundID    int    `json:"playground_id"`
 
 	DueDate string `json:"due_date"`
 	Status  string `json:"status"` // e.g., "not_started", "in_progress", "completed", "overdue"

--- a/internal/services/usecases/bookmark.usecases.go
+++ b/internal/services/usecases/bookmark.usecases.go
@@ -1,0 +1,46 @@
+package usecases
+
+import (
+	"context"
+
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/repository"
+	"github.com/TroJanBoi/assembly-visual-backend/internal/services/types"
+)
+
+type BookmarkUseCase interface {
+	CreateBookmarkUsecase(ctx context.Context, userID, classID int) error
+	DeleteBookmarkUsecase(ctx context.Context, userID, classID int) error
+	GetBookmarksByUserIDUsecase(ctx context.Context, userID int) (*[]types.ClassResponse, error)
+}
+
+type bookmarkUseCase struct {
+	bookmarkRepository repository.BookmarkRepository
+}
+
+func NewBookmarkUseCase(bookmarkRepository repository.BookmarkRepository) BookmarkUseCase {
+	return &bookmarkUseCase{
+		bookmarkRepository: bookmarkRepository,
+	}
+}
+
+func (b *bookmarkUseCase) CreateBookmarkUsecase(ctx context.Context, userID, classID int) error {
+	if err := b.bookmarkRepository.CreateBookmark(ctx, userID, classID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *bookmarkUseCase) DeleteBookmarkUsecase(ctx context.Context, userID, classID int) error {
+	if err := b.bookmarkRepository.DeleteBookmark(ctx, userID, classID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *bookmarkUseCase) GetBookmarksByUserIDUsecase(ctx context.Context, userID int) (*[]types.ClassResponse, error) {
+	bookmarks, err := b.bookmarkRepository.GetBookmarksByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return bookmarks, nil
+}

--- a/internal/services/usecases/class.usecases.go
+++ b/internal/services/usecases/class.usecases.go
@@ -20,6 +20,7 @@ type ClassUseCase interface {
 	ChangePermissionMemberUseCases(ctx context.Context, userID, classID int, newRole string) error
 	RemoveMemberInClassUseCases(ctx context.Context, classID, userID int) error
 	GetClassRecentManyIDsUseCases(ctx context.Context, limit []int) (*[]types.ClassResponse, error)
+	JoinWithCodeUseCases(ctx context.Context, userID int, code string) error
 }
 
 type classUseCase struct {
@@ -116,4 +117,12 @@ func (uc *classUseCase) GetClassRecentManyIDsUseCases(ctx context.Context, limit
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (uc *classUseCase) JoinWithCodeUseCases(ctx context.Context, userID int, code string) error {
+	err := uc.classRepo.JoinWithCode(ctx, userID, code)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/services/usecases/submission.usecases.go
+++ b/internal/services/usecases/submission.usecases.go
@@ -13,6 +13,7 @@ type SubmissionUseCase interface {
 	GetAllSubmissionByAssignmentIDUseCase(ctx context.Context, ownerID, assignmentID int) (*[]types.SubmissionResponse, error)
 	GetSubmissionByIDUseCase(ctx context.Context, userID, submissionID int) (*types.SubmissionResponse, error)
 	GetAllSubmissionByAssignmentIDandUserIDUseCase(ctx context.Context, assignmentID, userID int) (*[]types.SubmissionResponse, error)
+	UpdateGradeUseCase(ctx context.Context, userID, submissionID int, request types.UpdateGradeRequest) error
 }
 
 type submissionUseCase struct {
@@ -61,4 +62,12 @@ func (uc *submissionUseCase) GetAllSubmissionByAssignmentIDandUserIDUseCase(ctx 
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (uc *submissionUseCase) UpdateGradeUseCase(ctx context.Context, userID, submissionID int, request types.UpdateGradeRequest) error {
+	err := uc.submissionRepo.UpdateGrade(ctx, userID, submissionID, request)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/services/usecases/user.usecases.go
+++ b/internal/services/usecases/user.usecases.go
@@ -14,6 +14,7 @@ type UserUseCase interface {
 	DeleteUserUsecase(ctx context.Context, userID int) error
 	GetMeClassUsecase(ctx context.Context, userID int) (*[]types.ClassMeResponse, error)
 	GetOwnerClassUsecase(ctx context.Context, userID int) (*[]types.ClassMeResponse, error)
+	GetMeTaskUsecase(ctx context.Context, userID int) (*[]types.TaskMeResponse, error)
 }
 type userUseCase struct {
 	userRepository repository.UserRepository
@@ -68,4 +69,12 @@ func (u *userUseCase) GetOwnerClassUsecase(ctx context.Context, userID int) (*[]
 		return nil, err
 	}
 	return classes, nil
+}
+
+func (u *userUseCase) GetMeTaskUsecase(ctx context.Context, userID int) (*[]types.TaskMeResponse, error) {
+	tasks, err := u.userRepository.GetMeTask(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
 }


### PR DESCRIPTION
This pull request introduces several new features and API endpoints, along with enhancements to the data models and documentation. The primary focus is on adding bookmark functionality for classes, enabling class joining via code, supporting grade updates for submissions, and providing endpoints to retrieve user tasks. Several data models and Swagger documentation entries are updated to reflect these new features.

**Major new features and API endpoints:**

**Bookmark functionality:**
- Added a new `BookmarkController` with endpoints to create, delete, and retrieve bookmarks for classes (`/bookmark` POST, DELETE, GET). This includes the creation of `types.BookMarkRequest` and integration into the server routes. [[1]](diffhunk://#diff-a62f9be5a98ed5da8d8d8cbc67d362b3ca122187931425f915c6d2ef544965c2R1-R127) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R638-R741) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R26-R32) [[4]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R106-R109) [[5]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R174-R177)

**Classroom enhancements:**
- Added an endpoint to allow users to join a classroom using a unique code (`/classroom/join-with-code/{code}`), including controller logic and Swagger documentation. [[1]](diffhunk://#diff-312f103cc6498df23dd657232f82e766711960309cb0f6e681dad28b590ac0a5R358-R394) [[2]](diffhunk://#diff-312f103cc6498df23dd657232f82e766711960309cb0f6e681dad28b590ac0a5R403) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R1813-R1855)

**Submission and grading improvements:**
- Introduced an endpoint to update the grade for a submission (`/submission/{submission_id}/grade`) and the supporting request type (`types.UpdateGradeRequest`). [[1]](diffhunk://#diff-66cec1047ab1a45f037ce70fd8aab601751f891bb803a98880d8f9552ac9b30bR225-R278) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R2963-R3005) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R493-R504)
- Updated submission-related models and documentation to include feedback fields. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R150-R151) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R516-R517)

**User tasks:**
- Added a new endpoint to retrieve tasks for the authenticated user (`/user/me/task`) with the new response type `types.TaskMeResponse`. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R360-R381) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R3239-R3263)

**Other model and documentation updates:**
- Updated several Swagger definitions and data models for clarity, added/removed properties, and improved descriptions. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02L98-L99) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R185-L187) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R479-R480) [[4]](diffhunk://#diff-a9bab37dd98eab52edc49cffc78ead8505aad58343d913e06a249916cf32ae38L13-R13) [[5]](diffhunk://#diff-1f2992639668c2bbad47927c93ae107241421da67e57368495e16cceffb96eb0L11) [[6]](diffhunk://#diff-4a73d5a2d6149fbe90f66319f9809137cb7e2afb424ca052d8c7f010e582173fR4)

**Most important changes:**

**Bookmark feature:**
- Implemented `BookmarkController` with routes for creating, deleting, and retrieving bookmarks, and integrated it into the server routing. [[1]](diffhunk://#diff-a62f9be5a98ed5da8d8d8cbc67d362b3ca122187931425f915c6d2ef544965c2R1-R127) [[2]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R106-R109) [[3]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R174-R177)
- Added new Swagger documentation and request type for bookmark operations (`types.BookMarkRequest`). [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R26-R32) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R638-R741)

**Classroom improvements:**
- Added the ability for users to join a classroom using a unique code, including both the controller logic and the new API endpoint. [[1]](diffhunk://#diff-312f103cc6498df23dd657232f82e766711960309cb0f6e681dad28b590ac0a5R358-R394) [[2]](diffhunk://#diff-312f103cc6498df23dd657232f82e766711960309cb0f6e681dad28b590ac0a5R403) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R1813-R1855)

**Submission and grading:**
- Added an endpoint and controller logic to update grades for submissions, with support for feedback and verification. [[1]](diffhunk://#diff-66cec1047ab1a45f037ce70fd8aab601751f891bb803a98880d8f9552ac9b30bR225-R278) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R2963-R3005) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R493-R504) [[4]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R150-R151) [[5]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R516-R517)

**User tasks:**
- Introduced a new endpoint and response type for retrieving authenticated user tasks. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R360-R381) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R3239-R3263)

**Model and documentation updates:**
- Updated and clarified several Swagger definitions and data models, including assignment, classroom, and playground fields. [[1]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02L98-L99) [[2]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R185-L187) [[3]](diffhunk://#diff-79537685e8182a617fba40c71b310881d6a5cc418d8caed32ecf96bc3c0d4a02R479-R480) [[4]](diffhunk://#diff-a9bab37dd98eab52edc49cffc78ead8505aad58343d913e06a249916cf32ae38L13-R13) [[5]](diffhunk://#diff-1f2992639668c2bbad47927c93ae107241421da67e57368495e16cceffb96eb0L11) [[6]](diffhunk://#diff-4a73d5a2d6149fbe90f66319f9809137cb7e2afb424ca052d8c7f010e582173fR4)